### PR TITLE
feat: apply dark mode to admin

### DIFF
--- a/gestao/static/gestao/admin_custom.css
+++ b/gestao/static/gestao/admin_custom.css
@@ -1,7 +1,8 @@
 body {
-    background-color: #1c1c3a;
-    color: #ffffff;
-    font-family: Arial, sans-serif;
+    background-color: #18181b; /* zinc-900 */
+    color: #f4f4f5;            /* zinc-100 */
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+        "Noto Sans", sans-serif;
 }
 
 table {
@@ -9,32 +10,58 @@ table {
     border-collapse: collapse;
 }
 
-th, td {
+th,
+td {
     padding: 10px;
 }
 
 th {
-    background-color: #232345;
-    color: #b6a9ff;
+    background-color: #3f3f46; /* zinc-700 */
+    color: #e4e4e7;            /* zinc-200 */
 }
 
 tr:nth-child(even) {
-    background-color: #2d2d50;
+    background-color: #27272a; /* zinc-800 */
 }
 
 a {
-    color: #b67cff;
+    color: #a78bfa; /* violet-300 */
     text-decoration: none;
 }
 
 a:hover {
+    color: #c4b5fd; /* violet-200 */
     text-decoration: underline;
 }
 
+input,
+select,
+textarea {
+    background-color: #18181b; /* zinc-900 */
+    color: #f4f4f5;
+    border: 1px solid #3f3f46; /* zinc-700 */
+    border-radius: 0.375rem;    /* rounded-md */
+    padding: 0.5rem 0.75rem;   /* px-3 py-2 */
+}
+
+button {
+    background-color: #6d28d9; /* violet-700 */
+    color: #ffffff;
+    border: none;
+    padding: 0.5rem 1rem;      /* px-4 py-2 */
+    border-radius: 0.375rem;    /* rounded-md */
+    font-weight: 500;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #7c3aed; /* violet-600 */
+}
+
 .linha1 {
-    background-color: #f9f9f9;
+    background-color: #18181b;
 }
 
 .linha2 {
-    background-color: #ececec;
+    background-color: #27272a;
 }

--- a/gestao/templates/admin_custom/aeroportos.html
+++ b/gestao/templates/admin_custom/aeroportos.html
@@ -1,27 +1,39 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Aeroportos{% endblock %}
 {% block header_title %}Aeroportos{% endblock %}
-{% block menu_aeroportos %}active{% endblock %}
+{% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<form method="post" style="margin-bottom:20px;">
+<form method="post" class="bg-zinc-800 p-4 rounded-xl mb-6 space-y-4 max-w-xl">
     {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-</form>
-<table style="width:100%;background:#232345;border-radius:12px;overflow:hidden;">
-    <tr style="color:#b6a9ff;">
-        <th>Sigla</th>
-        <th>Nome</th>
-        <th></th>
-    </tr>
-    {% for a in aeroportos %}
-    <tr>
-        <td>{{ a.sigla }}</td>
-        <td>{{ a.nome }}</td>
-        <td><a href="{% url 'admin_editar_aeroporto' a.id %}" style="color:#b67cff;">Editar</a></td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="3" style="color:#ff7070;text-align:center;">Nenhum aeroporto cadastrado.</td></tr>
+    {% for field in form %}
+    <div>
+        <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+        {{ field }}
+        {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
+    </div>
     {% endfor %}
-</table>
+    <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+</form>
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Sigla</th>
+                <th class="p-2 text-left font-medium">Nome</th>
+                <th class="p-2 text-left font-medium"></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for a in aeroportos %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2">{{ a.sigla }}</td>
+                <td class="p-2">{{ a.nome }}</td>
+                <td class="p-2"><a href="{% url 'admin_editar_aeroporto' a.id %}" class="text-violet-300">Editar</a></td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="3" class="text-center text-red-400 py-4">Nenhum aeroporto cadastrado.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/aeroportos_form.html
+++ b/gestao/templates/admin_custom/aeroportos_form.html
@@ -1,11 +1,21 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Editar Aeroporto{% endblock %}
 {% block header_title %}Editar Aeroporto{% endblock %}
-{% block menu_aeroportos %}active{% endblock %}
+{% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-</form>
+<div class="max-w-xl mx-auto">
+    <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+        <div>
+            <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
+        </div>
+        {% endfor %}
+        <div class="flex justify-end">
+            <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+        </div>
+    </form>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -6,64 +6,39 @@
     <meta charset="UTF-8">
     <title>{% block title %}Administração{% endblock %} - Gestão de Pontos</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Opcional: Bootstrap CDN ou css próprio -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="{% static 'gestao/admin_custom.css' %}">
-    <style>
-        body { background: #17181d; color: #f6f6f6; }
-        .sidebar {
-            background: #222232;
-            min-height: 100vh;
-            padding-top: 2rem;
-            position: fixed;
-            width: 230px;
-            left: 0; top: 0;
-            box-shadow: 2px 0 18px #0004;
-        }
-        .sidebar .nav-link { color: #b6a9ff; font-weight: 500; margin: 12px 0; }
-        .sidebar .nav-link.active, .sidebar .nav-link:hover {
-            color: #fff; background: #3b3366; border-radius: 7px;
-        }
-        .content { margin-left: 250px; padding: 32px 24px 24px 24px; }
-        .admin-header { background: #232345; padding: 16px 24px; border-radius: 16px; display: flex; justify-content: space-between; align-items: center; }
-        .admin-header h1 { color: #b6a9ff; margin: 0; font-size: 1.5rem; }
-        .btn-logout { background: #35318e; color: #f6f6f6; border: none; border-radius: 6px; padding: 7px 16px; }
-        .btn-logout:hover { background: #5229b5; }
-        .main-card { background: #232345; border-radius: 16px; box-shadow: 0 2px 20px #0006; padding: 28px; margin-top: 32px;}
-        .main-card h2 { color: #b6a9ff; }
-    </style>
     {% block extra_head %}{% endblock %}
 </head>
-<body>
-    <div class="sidebar">
-        <div style="color:#b6a9ff;font-weight:700;letter-spacing:1px;margin-bottom:30px;padding-left:14px;font-size:1.15rem;">
-            <span style="color:#f8d16c">Gestão</span> Admin
+<body class="bg-zinc-900 text-white flex">
+    <aside class="bg-zinc-800 w-60 min-h-screen p-6 fixed shadow">
+        <div class="text-violet-300 font-bold tracking-wide mb-8 pl-2">
+            <span class="text-amber-300">Gestão</span> Admin
         </div>
-        <nav class="nav flex-column">
-            <a class="nav-link {% block menu_dashboard %}{% endblock %}" href="{% url 'admin_dashboard' %}">Dashboard</a>
-            <a class="nav-link {% block menu_clientes %}{% endblock %}" href="{% url 'admin_clientes' %}">Clientes</a>
-            <a class="nav-link {% block menu_contas %}{% endblock %}" href="{% url 'admin_contas' %}">Contas Fidelidade</a>
-            <a class="nav-link {% block menu_programas %}{% endblock %}" href="{% url 'admin_programas' %}">Programas</a>
-            <a class="nav-link {% block menu_aeroportos %}{% endblock %}" href="{% url 'admin_aeroportos' %}">Aeroportos</a>
-            <a class="nav-link {% block menu_companhias %}{% endblock %}" href="{% url 'admin_companhias' %}">Companhias</a>
-            <a class="nav-link {% block menu_cotacoes_voo %}{% endblock %}" href="{% url 'admin_cotacoes_voo' %}">Cotações</a>
-            <a class="nav-link {% block menu_emissoes %}{% endblock %}" href="{% url 'admin_emissoes' %}">Emissões</a>
-            <a class="nav-link {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
-            <a class="nav-link" href="{% url 'logout' %}">Sair</a>
+        <nav class="flex flex-col space-y-2">
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_dashboard %}{% endblock %}" href="{% url 'admin_dashboard' %}">Dashboard</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_clientes %}{% endblock %}" href="{% url 'admin_clientes' %}">Clientes</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_contas %}{% endblock %}" href="{% url 'admin_contas' %}">Contas Fidelidade</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_programas %}{% endblock %}" href="{% url 'admin_programas' %}">Programas</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_aeroportos %}{% endblock %}" href="{% url 'admin_aeroportos' %}">Aeroportos</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_companhias %}{% endblock %}" href="{% url 'admin_companhias' %}">Companhias</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_cotacoes_voo %}{% endblock %}" href="{% url 'admin_cotacoes_voo' %}">Cotações</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_emissoes %}{% endblock %}" href="{% url 'admin_emissoes' %}">Emissões</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700 {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
+            <a class="block px-3 py-2 rounded text-violet-300 hover:bg-zinc-700" href="{% url 'logout' %}">Sair</a>
         </nav>
-    </div>
-    <div class="content">
-        <div class="admin-header">
-            <h1>{% block header_title %}Painel Administrativo{% endblock %}</h1>
-            <div>
-                <span style="color:#f8d16c;">{{ request.user.get_full_name|default:request.user.username }}</span>
-                <a href="{% url 'logout' %}" class="btn btn-logout ms-2">Logout</a>
+    </aside>
+    <main class="flex-1 ml-60 p-8">
+        <header class="bg-zinc-800 rounded-xl p-4 mb-6 flex justify-between items-center shadow">
+            <h1 class="text-2xl font-bold text-violet-300">{% block header_title %}Painel Administrativo{% endblock %}</h1>
+            <div class="flex items-center space-x-2">
+                <span class="text-amber-300">{{ request.user.get_full_name|default:request.user.username }}</span>
+                <a href="{% url 'logout' %}" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Logout</a>
             </div>
-        </div>
-        <div class="main-card">
+        </header>
+        <section class="bg-zinc-800 rounded-xl shadow p-6">
             {% block content %}{% endblock %}
-        </div>
-    </div>
+        </section>
+    </main>
     {% block extra_body %}{% endblock %}
 </body>
 </html>

--- a/gestao/templates/admin_custom/cliente_form.html
+++ b/gestao/templates/admin_custom/cliente_form.html
@@ -1,11 +1,21 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Novo Cliente{% endblock %}
 {% block header_title %}Novo Cliente{% endblock %}
-{% block menu_clientes %}active{% endblock %}
+{% block menu_clientes %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-</form>
+<div class="max-w-xl mx-auto">
+    <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+        <div>
+            <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
+        </div>
+        {% endfor %}
+        <div class="flex justify-end">
+            <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+        </div>
+    </form>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/clientes.html
+++ b/gestao/templates/admin_custom/clientes.html
@@ -1,60 +1,60 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Clientes{% endblock %}
 {% block header_title %}Clientes Cadastrados{% endblock %}
-{% block menu_clientes %}active{% endblock %}
+{% block menu_clientes %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-    <div style="margin-bottom:1.2rem;display:flex;justify-content:space-between;align-items:center;">
-        <form method="get" style="display:flex;gap:8px;">
-            <input type="text" name="busca" value="{{ busca }}" placeholder="Buscar por nome ou usuário..." style="flex:1;padding:7px 13px;border-radius:8px;border:none;">
-            <button type="submit" style="padding:7px 18px;background:#b67cff;border:none;color:#232345;border-radius:8px;font-weight:bold;">Buscar</button>
-        </form>
-        <a href="{% url 'admin_novo_cliente' %}" style="background:#2b2b6f;color:#b67cff;padding:7px 14px;border-radius:8px;text-decoration:none;font-weight:bold;">Novo Cliente</a>
-    </div>
-    <div style="background:#232345;border-radius:12px;padding:8px 20px;">
-        <table style="width:100%;border-collapse:collapse;">
-            <thead>
-                <tr style="color:#b6a9ff;">
-                    <th style="padding:10px 4px;text-align:left;">Usuário</th>
-                    <th>Nome Completo</th>
-                    <th>E-mail</th>
-                    <th>CPF</th>
-                    <th>Telefone</th>
-                    <th>Perfil</th>
-                    <th>Status</th>
-                    <th>Ação</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cliente in page_obj %}
-                <tr>
-                    <td style="color:#ffe082;">{{ cliente.usuario.username }}</td>
-                    <td>{{ cliente.usuario.get_full_name }}</td>
-                    <td>{{ cliente.usuario.email }}</td>
-                    <td>{{ cliente.cpf }}</td>
-                    <td>{{ cliente.telefone }}</td>
-                    <td>{{ cliente.get_perfil_display }}</td>
-                    <td>{{ cliente.ativo|yesno:"Ativo,Inativo" }}</td>
-                    <td>
-                        <a href="{% url 'admin_editar_cliente' cliente.id %}" style="color:#b67cff;">Editar</a> |
-                        <a href="?toggle={{ cliente.id }}" style="color:#b67cff;">Ativar/Inativar</a>
-                    </td>
-                </tr>
-                {% empty %}
-                <tr><td colspan="6" style="color:#fa7070;text-align:center;padding:2rem 0;">Nenhum cliente encontrado.</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        {% if page_obj.has_other_pages %}
-        <div style="margin:16px 0;display:flex;gap:6px;justify-content:center;">
-            {% if page_obj.has_previous %}
-            <a href="?page={{ page_obj.previous_page_number }}&busca={{ busca }}" style="background:#444a85;color:#fff;padding:4px 14px;border-radius:7px;">&lt;</a>
-            {% endif %}
-            <span style="color:#b6a9ff;padding:2px 11px;">Página {{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span>
-            {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}&busca={{ busca }}" style="background:#444a85;color:#fff;padding:4px 14px;border-radius:7px;">&gt;</a>
-            {% endif %}
-        </div>
-        {% endif %}
-    </div>
-    <div style="color:#aaa;font-size:0.97rem;margin-top:11px;">Total: {{ total_clientes }} clientes cadastrados.</div>
+<div class="flex justify-between items-center mb-6 flex-wrap gap-4">
+    <form method="get" class="flex gap-3">
+        <input type="text" name="busca" value="{{ busca }}" placeholder="Buscar por nome ou usuário..." class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2" />
+        <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Buscar</button>
+    </form>
+    <a href="{% url 'admin_novo_cliente' %}" class="bg-zinc-700 text-violet-300 px-4 py-2 rounded font-bold">Novo Cliente</a>
+</div>
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Usuário</th>
+                <th class="p-2 text-left font-medium">Nome Completo</th>
+                <th class="p-2 text-left font-medium">E-mail</th>
+                <th class="p-2 text-left font-medium">CPF</th>
+                <th class="p-2 text-left font-medium">Telefone</th>
+                <th class="p-2 text-left font-medium">Perfil</th>
+                <th class="p-2 text-left font-medium">Status</th>
+                <th class="p-2 text-left font-medium">Ação</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cliente in page_obj %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2 text-amber-300">{{ cliente.usuario.username }}</td>
+                <td class="p-2">{{ cliente.usuario.get_full_name }}</td>
+                <td class="p-2">{{ cliente.usuario.email }}</td>
+                <td class="p-2">{{ cliente.cpf }}</td>
+                <td class="p-2">{{ cliente.telefone }}</td>
+                <td class="p-2">{{ cliente.get_perfil_display }}</td>
+                <td class="p-2">{{ cliente.ativo|yesno:"Ativo,Inativo" }}</td>
+                <td class="p-2">
+                    <a href="{% url 'admin_editar_cliente' cliente.id %}" class="text-violet-300">Editar</a> |
+                    <a href="?toggle={{ cliente.id }}" class="text-violet-300">Ativar/Inativar</a>
+                </td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="8" class="text-center text-red-400 py-4">Nenhum cliente encontrado.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% if page_obj.has_other_pages %}
+<div class="mt-4 flex gap-2 justify-center">
+    {% if page_obj.has_previous %}
+    <a href="?page={{ page_obj.previous_page_number }}&busca={{ busca }}" class="bg-zinc-700 text-white px-3 py-1 rounded">&lt;</a>
+    {% endif %}
+    <span class="text-zinc-300 px-3 py-1">Página {{ page_obj.number }}/{{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+    <a href="?page={{ page_obj.next_page_number }}&busca={{ busca }}" class="bg-zinc-700 text-white px-3 py-1 rounded">&gt;</a>
+    {% endif %}
+</div>
+{% endif %}
+<div class="text-zinc-400 mt-4 text-sm">Total: {{ total_clientes }} clientes cadastrados.</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/companhias.html
+++ b/gestao/templates/admin_custom/companhias.html
@@ -1,33 +1,36 @@
 {% extends "admin_custom/base_admin.html" %}
+{% block title %}Companhias Aéreas{% endblock %}
 {% block header_title %}Companhias Aéreas{% endblock %}
-{% block menu_companhias %}active{% endblock %}
+{% block menu_companhias %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<div class="flex justify-between items-center mb-4">
-  <h2 class="text-xl font-semibold">Companhias Aéreas</h2>
+<div class="flex justify-between items-center mb-6">
+  <h2 class="text-2xl font-bold">Companhias Aéreas</h2>
   <a href="{% url 'admin_nova_companhia' %}" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Nova Companhia</a>
 </div>
-<table class="min-w-full text-sm">
-  <thead class="bg-zinc-700 text-gray-200">
-    <tr>
-      <th class="p-3 text-left font-medium">Nome</th>
-      <th class="p-3 text-left font-medium">Site</th>
-      <th class="p-3 text-left font-medium">Ações</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for companhia in companhias %}
-    <tr class="border-b border-zinc-700 hover:bg-zinc-800">
-      <td class="p-3">{{ companhia.nome }}</td>
-      <td class="p-3"><a href="{{ companhia.site_url }}" class="text-blue-400" target="_blank">{{ companhia.site_url }}</a></td>
-      <td class="p-3">
-        <a href="{% url 'admin_editar_companhia' companhia.id %}" class="text-violet-400 hover:underline">Editar</a>
-      </td>
-    </tr>
-    {% empty %}
-    <tr>
-      <td colspan="3" class="p-3 text-center text-zinc-400">Nenhuma companhia cadastrada.</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="bg-zinc-800 rounded-xl overflow-x-auto">
+  <table class="min-w-full text-sm">
+    <thead class="bg-zinc-700 text-gray-200">
+      <tr>
+        <th class="p-3 text-left font-medium">Nome</th>
+        <th class="p-3 text-left font-medium">Site</th>
+        <th class="p-3 text-left font-medium">Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for companhia in companhias %}
+      <tr class="border-b border-zinc-700 hover:bg-zinc-800">
+        <td class="p-3">{{ companhia.nome }}</td>
+        <td class="p-3"><a href="{{ companhia.site_url }}" class="text-blue-400" target="_blank">{{ companhia.site_url }}</a></td>
+        <td class="p-3">
+          <a href="{% url 'admin_editar_companhia' companhia.id %}" class="text-violet-400 hover:underline">Editar</a>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="3" class="p-3 text-center text-zinc-400">Nenhuma companhia cadastrada.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/companhias_form.html
+++ b/gestao/templates/admin_custom/companhias_form.html
@@ -1,18 +1,22 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block header_title %}Companhias Aéreas{% endblock %}
-{% block menu_companhias %}active{% endblock %}
+{% block menu_companhias %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<h2 class="text-xl font-semibold mb-4">{% if form.instance.pk %}Editar Companhia{% else %}Nova Companhia{% endif %}</h2>
-<form method="post" class="space-y-4">
-  {% csrf_token %}
-  <div>
-    {{ form.nome.label_tag }}
-    {{ form.nome }}
-  </div>
-  <div>
-    {{ form.site_url.label_tag }}
-    {{ form.site_url }}
-  </div>
-  <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
-</form>
+<div class="max-w-xl mx-auto">
+  <h2 class="text-2xl font-bold mb-4">{% if form.instance.pk %}Editar Companhia{% else %}Nova Companhia{% endif %}</h2>
+  <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
+    {% csrf_token %}
+    <div>
+      <label class="block mb-1 text-sm text-zinc-300">{{ form.nome.label }}</label>
+      {{ form.nome }}
+    </div>
+    <div>
+      <label class="block mb-1 text-sm text-zinc-300">{{ form.site_url.label }}</label>
+      {{ form.site_url }}
+    </div>
+    <div class="flex justify-end">
+      <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+    </div>
+  </form>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/contas.html
+++ b/gestao/templates/admin_custom/contas.html
@@ -1,7 +1,7 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Contas de Fidelidade{% endblock %}
 {% block header_title %}Contas de Fidelidade{% endblock %}
-{% block menu_contas %}active{% endblock %}
+{% block menu_contas %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
     <div style="margin-bottom:1.2rem; display: flex; justify-content: space-between; align-items: center;">
         <a href="{% url 'admin_nova_conta' %}" style="background:#b67cff;color:#232345;padding:8px 16px;border-radius:8px;font-weight:bold;text-decoration:none;">

--- a/gestao/templates/admin_custom/cotacoes.html
+++ b/gestao/templates/admin_custom/cotacoes.html
@@ -1,43 +1,43 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Cotações do Milheiro{% endblock %}
 {% block header_title %}Cotações do Milheiro{% endblock %}
-{% block menu_cotacoes %}active{% endblock %}
+{% block menu_cotacoes %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-    <h2 style="color:#b67cff;">Atualizar cotação do milheiro</h2>
-    <form method="post" style="margin-bottom:22px;">
-        {% csrf_token %}
-        <select name="programa_nome" required style="padding:8px 14px;border-radius:9px;">
-            <option value="">-- Programa --</option>
-            {% for p in programas %}
-            <option value="{{ p.nome }}">{{ p.nome }}</option>
-            {% endfor %}
-        </select>
-        <input type="number" step="0.01" min="0" name="valor_mercado" placeholder="Valor mercado" required style="padding:8px 10px;border-radius:8px;width:120px;">
-        <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-    </form>
+<h2 class="text-violet-400 text-xl font-semibold mb-4">Atualizar cotação do milheiro</h2>
+<form method="post" class="flex flex-wrap gap-3 items-end mb-6">
+    {% csrf_token %}
+    <select name="programa_nome" required class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2">
+        <option value="">-- Programa --</option>
+        {% for p in programas %}
+        <option value="{{ p.nome }}">{{ p.nome }}</option>
+        {% endfor %}
+    </select>
+    <input type="number" step="0.01" min="0" name="valor_mercado" placeholder="Valor mercado" required class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2 w-36" />
+    <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+</form>
 
-    <div style="background:#232345;border-radius:12px;padding:18px 20px;">
-        <table style="width:100%;border-collapse:collapse;">
-            <thead>
-                <tr style="color:#b6a9ff;">
-                    <th style="padding:10px 4px;text-align:left;">Programa</th>
-                    <th>Cotação Mercado</th>
-                    <th>Última atualização</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cot in cotacoes %}
-                <tr>
-                    <td>{{ cot.programa_nome }}</td>
-                    <td>R$ {{ cot.valor_mercado|floatformat:2 }}</td>
-                    <td>{{ cot.atualizado_em|date:"d/m/Y" }}</td>
-                </tr>
-                {% empty %}
-                <tr>
-                    <td colspan="3" style="color:#fa7070;text-align:center;">Nenhuma cotação cadastrada.</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Programa</th>
+                <th class="p-2 text-left font-medium">Cotação Mercado</th>
+                <th class="p-2 text-left font-medium">Última atualização</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cot in cotacoes %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2">{{ cot.programa_nome }}</td>
+                <td class="p-2">R$ {{ cot.valor_mercado|floatformat:2 }}</td>
+                <td class="p-2">{{ cot.atualizado_em|date:"d/m/Y" }}</td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td colspan="3" class="text-center text-red-400 py-4">Nenhuma cotação cadastrada.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/cotacoes_voo.html
+++ b/gestao/templates/admin_custom/cotacoes_voo.html
@@ -1,50 +1,50 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Cotações de Voo{% endblock %}
 {% block header_title %}Cotações de Voo{% endblock %}
-{% block menu_cotacoes_voo %}active{% endblock %}
+{% block menu_cotacoes_voo %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-    <div style="margin-bottom:1.2rem;text-align:right;">
-        <a href="{% url 'admin_nova_cotacao_voo' %}" style="background:#2b2b6f;color:#b67cff;padding:7px 14px;border-radius:8px;text-decoration:none;font-weight:bold;">Nova Cotação</a>
-    </div>
-    <div style="background:#232345;border-radius:12px;padding:18px 18px 5px 18px;">
-        <table style="width:100%;border-collapse:collapse;">
-            <thead>
-                <tr style="color:#b6a9ff;">
-                    <th>Cliente</th>
-                    <th>Origem</th>
-                    <th>Destino</th>
-                    <th>Data Ida</th>
-                    <th>Valor Parcelado</th>
-                    <th>Valor à Vista</th>
-                    <th>Valor Referencia</th>
-                    <th>Economia de até</th>
-                    <th>Status</th>
-                    <th></th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for c in cotacoes %}
-                <tr>
-                    <td>{{ c.cliente.usuario.get_full_name|default:c.cliente.usuario.username }}</td>
-                    <td>{{ c.origem }}</td>
-                    <td>{{ c.destino }}</td>
-                    <td>{{ c.data_ida|date:"d/m/Y H:i" }}</td>
-                    <td>R$ {{ c.valor_parcelado|floatformat:2 }}</td>
-                    <td>R$ {{ c.valor_vista|floatformat:2 }}</td>
-                    <td>R$ {{ c.valor_passagem|floatformat:2 }}</td>
-                    <td>R$ {{ c.economia|floatformat:2 }}</td>
-                    <td>{{ c.get_status_display }}</td>
-                    <td><a href="{% url 'admin_editar_cotacao_voo' c.id %}" style="color:#b67cff;">Editar</a></td>
-                    <td>
-                        <a href="{% url 'admin_cotacao_voo_pdf' c.id %}" style="color:#b67cff;">PDF</a> |
-                        <a href="{% url 'admin_editar_cotacao_voo' c.id %}" style="color:#b67cff;">Editar</a>
-                    </td>
-                </tr>
-                {% empty %}
-                <tr><td colspan="8" style="color:#ff7070;text-align:center;">Nenhuma cotação encontrada.</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+<div class="mb-6 text-right">
+    <a href="{% url 'admin_nova_cotacao_voo' %}" class="bg-zinc-700 text-violet-300 px-4 py-2 rounded font-bold">Nova Cotação</a>
+</div>
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Cliente</th>
+                <th class="p-2 text-left font-medium">Origem</th>
+                <th class="p-2 text-left font-medium">Destino</th>
+                <th class="p-2 text-left font-medium">Data Ida</th>
+                <th class="p-2 text-left font-medium">Valor Parcelado</th>
+                <th class="p-2 text-left font-medium">Valor à Vista</th>
+                <th class="p-2 text-left font-medium">Valor Referência</th>
+                <th class="p-2 text-left font-medium">Economia de até</th>
+                <th class="p-2 text-left font-medium">Status</th>
+                <th class="p-2 text-left font-medium"></th>
+                <th class="p-2 text-left font-medium">Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in cotacoes %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2">{{ c.cliente.usuario.get_full_name|default:c.cliente.usuario.username }}</td>
+                <td class="p-2">{{ c.origem }}</td>
+                <td class="p-2">{{ c.destino }}</td>
+                <td class="p-2">{{ c.data_ida|date:"d/m/Y H:i" }}</td>
+                <td class="p-2">R$ {{ c.valor_parcelado|floatformat:2 }}</td>
+                <td class="p-2">R$ {{ c.valor_vista|floatformat:2 }}</td>
+                <td class="p-2">R$ {{ c.valor_passagem|floatformat:2 }}</td>
+                <td class="p-2">R$ {{ c.economia|floatformat:2 }}</td>
+                <td class="p-2">{{ c.get_status_display }}</td>
+                <td class="p-2"><a href="{% url 'admin_editar_cotacao_voo' c.id %}" class="text-violet-300">Editar</a></td>
+                <td class="p-2">
+                    <a href="{% url 'admin_cotacao_voo_pdf' c.id %}" class="text-violet-300">PDF</a> |
+                    <a href="{% url 'admin_editar_cotacao_voo' c.id %}" class="text-violet-300">Editar</a>
+                </td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="11" class="text-center text-red-400 py-4">Nenhuma cotação encontrada.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/cotacoes_voo_form.html
+++ b/gestao/templates/admin_custom/cotacoes_voo_form.html
@@ -1,11 +1,23 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Nova Cotação de Voo{% endblock %}
 {% block header_title %}Nova Cotação de Voo{% endblock %}
-{% block menu_cotacoes_voo %}active{% endblock %}
+{% block menu_cotacoes_voo %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-</form>
+<div class="max-w-xl mx-auto">
+    <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+        <div>
+            <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}
+            <div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>
+            {% endif %}
+        </div>
+        {% endfor %}
+        <div class="flex justify-end">
+            <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+        </div>
+    </form>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Dashboard{% endblock %}
 {% block header_title %}Dashboard Administrativo{% endblock %}
-{% block menu_dashboard %}active{% endblock %}
+{% block menu_dashboard %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
     <div class="row">
         <div class="col-md-3 mb-3">

--- a/gestao/templates/admin_custom/emissoes.html
+++ b/gestao/templates/admin_custom/emissoes.html
@@ -1,93 +1,95 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Emissões Detalhadas{% endblock %}
 {% block header_title %}Emissões Detalhadas{% endblock %}
-{% block menu_emissoes %}active{% endblock %}
+{% block menu_emissoes %}bg-zinc-700 text-white{% endblock %}
 
 {% block content %}
-    <form method="get" style="margin-bottom:18px;display:flex;gap:10px;flex-wrap:wrap;align-items:end;">
-        <div>
-            <label style="color:#aaa;">Cliente</label>
-            <select name="cliente" style="padding:7px 12px;border-radius:8px;">
-                <option value="">Todos</option>
-                {% for c in clientes %}
-                <option value="{{ c.id }}" {% if params.cliente == c.id|stringformat:'s' %}selected{% endif %}>
-                    {{ c.usuario.get_full_name|default:c.usuario.username }}
-                </option>
-                {% endfor %}
-             </select>
-        </div>
-        <div>
-            <label style="color:#aaa;">Programa</label>
-            <select name="programa" style="padding:7px 12px;border-radius:8px;">
-                <option value="">Todos</option>
-                {% for p in programas %}
-                <option value="{{ p.id }}" {% if params.programa == p.id|stringformat:'s' %}selected{% endif %}>{{ p.nome }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div>
-            <label style="color:#aaa;">Buscar aeroporto ou nome</label>
-            <input type="text" name="q" value="{{ params.q|default_if_none:'' }}" placeholder="Buscar" style="padding:7px 12px;border-radius:8px;">
-        </div>
-        <div>
-            <label style="color:#aaa;">Data ida de</label>
-            <input type="date" name="data_ini" value="{{ params.data_ini|default_if_none:'' }}" style="padding:7px 12px;border-radius:8px;">
-        </div>
-        <div>
-            <label style="color:#aaa;">Data volta até</label>
-            <input type="date" name="data_fim" value="{{ params.data_fim|default_if_none:'' }}" style="padding:7px 12px;border-radius:8px;">
-        </div>
-        <button style="background:#b67cff;color:#232345;font-weight:bold;padding:7px 22px;border-radius:8px;margin-bottom:3px;">Filtrar</button>
-        <a href="?export=excel{% if params.q %}&q={{ params.q }}{% endif %}" style="background:#2b2b6f;color:#b67cff;padding:7px 17px;border-radius:8px;text-decoration:none;margin-left:7px;font-weight:600;">Exportar Excel</a>
-        <a href="{% url 'admin_nova_emissao' %}" style="background:#2b2b6f;color:#b67cff;padding:7px 14px;border-radius:8px;text-decoration:none;font-weight:bold;margin-left:7px;">Nova Emissão</a>
-    </form>
-    <div style="background:#232345;border-radius:12px;padding:18px 18px 5px 18px;">
-        <table style="width:100%;border-collapse:collapse;">
-            <thead>
-                <tr style="color:#b6a9ff;">
-                    <th>Cliente</th>
-                    <th>Programa</th>
-                    <th>Aeroporto Ida</th>
-                    <th>Aeroporto Volta</th>
-                    <th>Data Ida</th>
-                    <th>Data Volta</th>
-                    <th>Qtd</th>
-                    <th>Companhia</th>
-                    <th>Localizador</th>
-                    <th>Valor Ref.</th>
-                    <th>Pago</th>
-                    <th>Pontos</th>
-                    <th>Economia</th>
-                    <th>Detalhes</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for e in emissoes %}
-                <tr>
-                    <td>{{ e.cliente.usuario.get_full_name|default:e.cliente.usuario.username }}</td>
-                    <td>{{ e.programa }}</td>
-                    <td>{{ e.aeroporto_partida }}</td>
-                    <td>{{ e.aeroporto_destino }}</td>
-                    <td>{{ e.data_ida|date:"d/m/Y H:i" }}</td>
-                    <td>{{ e.data_volta|date:"d/m/Y H:i" }}</td>
-                    <td>{{ e.qtd_passageiros }}</td>
-                    <td>{{ e.companhia_aerea }}</td>
-                    <td>{{ e.localizador }}</td>
-                    <td>R$ {{ e.valor_referencia|floatformat:2 }}</td>
-                    <td>R$ {{ e.valor_pago|floatformat:2 }}</td>
-                    <td>{{ e.pontos_utilizados }}</td>
-                    <td>R$ {{ e.economia_obtida|floatformat:2 }}</td>
-                    <td>{{ e.detalhes }}</td>
-                    <td>
-                        <a href="{% url 'admin_emissao_pdf' e.id %}" style="color:#b67cff;">PDF</a> |
-                        <a href="{% url 'admin_editar_emissao' e.id %}" style="color:#b67cff;">Editar</a>
-                    </td>
-                </tr>
-                {% empty %}
-                <tr><td colspan="15" style="color:#ff7070;text-align:center;">Nenhuma emissão encontrada.</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
+<form method="get" class="flex flex-wrap gap-3 items-end mb-6">
+    <div>
+        <label class="text-sm text-zinc-300 block mb-1">Cliente</label>
+        <select name="cliente" class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2">
+            <option value="">Todos</option>
+            {% for c in clientes %}
+            <option value="{{ c.id }}" {% if params.cliente == c.id|stringformat:'s' %}selected{% endif %}>
+                {{ c.usuario.get_full_name|default:c.usuario.username }}
+            </option>
+            {% endfor %}
+        </select>
     </div>
+    <div>
+        <label class="text-sm text-zinc-300 block mb-1">Programa</label>
+        <select name="programa" class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2">
+            <option value="">Todos</option>
+            {% for p in programas %}
+            <option value="{{ p.id }}" {% if params.programa == p.id|stringformat:'s' %}selected{% endif %}>{{ p.nome }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label class="text-sm text-zinc-300 block mb-1">Buscar aeroporto ou nome</label>
+        <input type="text" name="q" value="{{ params.q|default_if_none:'' }}" placeholder="Buscar" class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2" />
+    </div>
+    <div>
+        <label class="text-sm text-zinc-300 block mb-1">Data ida de</label>
+        <input type="date" name="data_ini" value="{{ params.data_ini|default_if_none:'' }}" class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2" />
+    </div>
+    <div>
+        <label class="text-sm text-zinc-300 block mb-1">Data volta até</label>
+        <input type="date" name="data_fim" value="{{ params.data_fim|default_if_none:'' }}" class="bg-zinc-900 border border-zinc-600 rounded px-3 py-2" />
+    </div>
+    <button class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Filtrar</button>
+    <a href="?export=excel{% if params.q %}&q={{ params.q }}{% endif %}" class="bg-zinc-700 text-violet-300 px-4 py-2 rounded">Exportar Excel</a>
+    <a href="{% url 'admin_nova_emissao' %}" class="bg-zinc-700 text-violet-300 px-4 py-2 rounded font-bold">Nova Emissão</a>
+</form>
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Cliente</th>
+                <th class="p-2 text-left font-medium">Programa</th>
+                <th class="p-2 text-left font-medium">Aeroporto Ida</th>
+                <th class="p-2 text-left font-medium">Aeroporto Volta</th>
+                <th class="p-2 text-left font-medium">Data Ida</th>
+                <th class="p-2 text-left font-medium">Data Volta</th>
+                <th class="p-2 text-left font-medium">Qtd</th>
+                <th class="p-2 text-left font-medium">Companhia</th>
+                <th class="p-2 text-left font-medium">Localizador</th>
+                <th class="p-2 text-left font-medium">Valor Ref.</th>
+                <th class="p-2 text-left font-medium">Pago</th>
+                <th class="p-2 text-left font-medium">Pontos</th>
+                <th class="p-2 text-left font-medium">Economia</th>
+                <th class="p-2 text-left font-medium">Detalhes</th>
+                <th class="p-2 text-left font-medium">Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for e in emissoes %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2">{{ e.cliente.usuario.get_full_name|default:e.cliente.usuario.username }}</td>
+                <td class="p-2 text-blue-400 font-medium">{{ e.programa }}</td>
+                <td class="p-2">{{ e.aeroporto_partida }}</td>
+                <td class="p-2">{{ e.aeroporto_destino }}</td>
+                <td class="p-2">{{ e.data_ida|date:"d/m/Y H:i" }}</td>
+                <td class="p-2">{{ e.data_volta|date:"d/m/Y H:i" }}</td>
+                <td class="p-2">{{ e.qtd_passageiros }}</td>
+                <td class="p-2">{{ e.companhia_aerea }}</td>
+                <td class="p-2">{{ e.localizador }}</td>
+                <td class="p-2 text-green-400 font-semibold">R$ {{ e.valor_referencia|floatformat:2 }}</td>
+                <td class="p-2">R$ {{ e.valor_pago|floatformat:2 }}</td>
+                <td class="p-2">{{ e.pontos_utilizados }}</td>
+                <td class="p-2 text-green-400 font-semibold">R$ {{ e.economia_obtida|floatformat:2 }}</td>
+                <td class="p-2">{{ e.detalhes }}</td>
+                <td class="p-2">
+                    <a href="{% url 'admin_emissao_pdf' e.id %}" class="text-violet-300">PDF</a> |
+                    <a href="{% url 'admin_editar_emissao' e.id %}" class="text-violet-300">Editar</a>
+                </td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td colspan="15" class="text-center text-red-400 py-4">Nenhuma emissão encontrada.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/emissoes_form.html
+++ b/gestao/templates/admin_custom/emissoes_form.html
@@ -1,15 +1,16 @@
 {% block title %}{% if form.instance.pk %}Editar Emissão{% else %}Nova Emissão{% endif %}{% endblock %}
 {% block header_title %}{% if form.instance.pk %}Editar Emissão{% else %}Nova Emissão{% endif %}{% endblock %}
-{% block menu_emissoes %}active{% endblock %}
+{% block menu_emissoes %}bg-zinc-700 text-white{% endblock %}
 
 {% block extra_head %}
 <style>
 body {
-  background: #f9f9fb;
+  background: #18181b;
+  color: #f4f4f5;
   font-family: 'Inter', Arial, sans-serif;
 }
 .content {
-  background: #f9f9fb;
+  background: #18181b;
 }
 .main-card {
   background: transparent;
@@ -19,10 +20,10 @@ body {
   justify-content: center;
 }
 .form-card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: #27272a;
+  border: 1px solid #3f3f46;
   border-radius: 16px;
-  box-shadow: 0 2px 16px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 16px rgba(0,0,0,0.2);
   padding: 32px 40px;
   max-width: 520px;
   width: 100%;
@@ -30,14 +31,14 @@ body {
 .form-title {
   font-size: 2.2rem;
   font-weight: 700;
-  color: #232345;
+  color: #f4f4f5;
   margin-bottom: 24px;
   text-align: center;
 }
 .section-title {
   font-size: 1.15rem;
   font-weight: 600;
-  color: #232345;
+  color: #e4e4e7;
   margin: 26px 0 12px 0;
 }
 .form-group {
@@ -51,7 +52,7 @@ body {
 }
 .form-label {
   font-size: 1rem;
-  color: #232345;
+  color: #e4e4e7;
   font-weight: 500;
   display: block;
   margin-bottom: 6px;
@@ -61,9 +62,10 @@ body {
 .form-card textarea {
   width: 100%;
   padding: 10px 14px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid #3f3f46;
   border-radius: 8px;
-  background: #fff;
+  background: #18181b;
+  color: #f4f4f5;
   font-size: 1rem;
   margin-bottom: 2px;
   transition: border 0.2s;
@@ -71,7 +73,7 @@ body {
 .form-card input:focus,
 .form-card select:focus,
 .form-card textarea:focus {
-  border-color: #2563eb;
+  border-color: #7c3aed;
   outline: none;
 }
 .form-card textarea {
@@ -84,7 +86,7 @@ body {
   margin-top: 22px;
 }
 .btn-primary {
-  background: #2563eb;
+  background: #6d28d9;
   color: #fff;
   font-weight: 600;
   border: none;
@@ -92,11 +94,11 @@ body {
   padding: 12px 32px;
   cursor: pointer;
   font-size: 1rem;
-  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.07);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
   transition: background 0.18s;
 }
 .btn-primary:hover {
-  background: #1745b7;
+  background: #7c3aed;
 }
 .existing-table {
   width: 100%;
@@ -105,13 +107,13 @@ body {
 .existing-table th,
 .existing-table td {
   padding: 8px 12px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid #3f3f46;
   text-align: left;
-  color: #232345;
+  color: #f4f4f5;
   font-size: 0.9rem;
 }
 .existing-table th {
-  background: #f3f4f6;
+  background: #3f3f46;
   font-weight: 600;
 }
 </style>
@@ -258,7 +260,7 @@ body {
                     <td>{{ e.aeroporto_destino }}</td>
                     <td>{{ e.data_ida|date:"d/m/Y H:i" }}</td>
                     <td>{{ e.data_volta|date:"d/m/Y H:i" }}</td>
-                    <td><a href="{% url 'admin_editar_emissao' e.id %}" style="color:#2563eb;">Editar</a></td>
+                    <td><a href="{% url 'admin_editar_emissao' e.id %}" class="text-violet-400">Editar</a></td>
                 </tr>
                 {% empty %}
                 <tr><td colspan="7">Nenhuma emissão encontrada.</td></tr>

--- a/gestao/templates/admin_custom/hoteis.html
+++ b/gestao/templates/admin_custom/hoteis.html
@@ -1,7 +1,7 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Emissões de Hotéis{% endblock %}
 {% block header_title %}Emissões de Hotéis{% endblock %}
-{% block menu_hoteis %}active{% endblock %}
+{% block menu_hoteis %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
     <a href="{% url 'admin_nova_emissao_hotel' %}" style="background:#2b2b6f;color:#b67cff;padding:7px 14px;border-radius:8px;text-decoration:none;font-weight:bold;">Nova Emissão</a>
     <div style="background:#232345;border-radius:12px;padding:18px 18px 5px 18px;margin-top:10px;">

--- a/gestao/templates/admin_custom/hoteis_form.html
+++ b/gestao/templates/admin_custom/hoteis_form.html
@@ -1,7 +1,7 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Nova Emissão de Hotel{% endblock %}
 {% block header_title %}Nova Emissão de Hotel{% endblock %}
-{% block menu_hoteis %}active{% endblock %}
+{% block menu_hoteis %}bg-zinc-700 text-white{% endblock %}
 
 {% block content %}
 <form method="post">

--- a/gestao/templates/admin_custom/programas.html
+++ b/gestao/templates/admin_custom/programas.html
@@ -1,38 +1,46 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Programas{% endblock %}
 {% block header_title %}Programas de Pontos{% endblock %}
-{% block menu_programas %}active{% endblock %}
+{% block menu_programas %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-    <form method="post" style="margin-bottom:20px;">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-    </form>
-
-    <div style="background:#232345;border-radius:12px;padding:8px 20px;">
-        <table style="width:100%;border-collapse:collapse;">
-            <thead>
-                <tr style="color:#b6a9ff;">
-                    <th>Nome</th>
-                    <th>Valor Referência</th>
-                    <th>Descrição</th>
-                    <th>Valor Referência</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for p in programas %}
-                <tr>
-                    <td>{{ p.nome }}</td>
-                    <td>R$ {{ p.preco_medio_milheiro|floatformat:2 }}</td>
-                    <td>{{ p.descricao }}</td>
-                    <td>R$ {{ p.preco_medio_milheiro|floatformat:2 }}</td>
-                    <td><a href="{% url 'admin_editar_programa' p.id %}" style="color:#b67cff;">Editar</a></td>
-                </tr>
-                {% empty %}
-                <tr><td colspan="4" style="color:#ff7070;text-align:center;">Nenhum programa cadastrado.</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
+<form method="post" class="bg-zinc-800 p-4 rounded-xl mb-6 space-y-4 max-w-xl">
+    {% csrf_token %}
+    {% for field in form %}
+    <div>
+        <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+        {{ field }}
+        {% if field.errors %}
+        <div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>
+        {% endif %}
     </div>
+    {% endfor %}
+    <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+</form>
+
+<div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
+    <table class="min-w-full text-sm">
+        <thead class="bg-zinc-700 text-zinc-200">
+            <tr>
+                <th class="p-2 text-left font-medium">Nome</th>
+                <th class="p-2 text-left font-medium">Valor Referência</th>
+                <th class="p-2 text-left font-medium">Descrição</th>
+                <th class="p-2 text-left font-medium">Valor Referência</th>
+                <th class="p-2 text-left font-medium"></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in programas %}
+            <tr class="border-b border-zinc-700">
+                <td class="p-2">{{ p.nome }}</td>
+                <td class="p-2">R$ {{ p.preco_medio_milheiro|floatformat:2 }}</td>
+                <td class="p-2">{{ p.descricao }}</td>
+                <td class="p-2">R$ {{ p.preco_medio_milheiro|floatformat:2 }}</td>
+                <td class="p-2"><a href="{% url 'admin_editar_programa' p.id %}" class="text-violet-300">Editar</a></td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="5" class="text-center text-red-400 py-4">Nenhum programa cadastrado.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/gestao/templates/admin_custom/programas_form.html
+++ b/gestao/templates/admin_custom/programas_form.html
@@ -1,11 +1,21 @@
 {% extends "admin_custom/base_admin.html" %}
 {% block title %}Editar Programa{% endblock %}
 {% block header_title %}Editar Programa{% endblock %}
-{% block menu_programas %}active{% endblock %}
+{% block menu_programas %}bg-zinc-700 text-white{% endblock %}
 {% block content %}
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" style="background:#b67cff;color:#232345;border:none;padding:8px 20px;border-radius:8px;font-weight:bold;">Salvar</button>
-</form>
+<div class="max-w-xl mx-auto">
+    <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+        <div>
+            <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
+        </div>
+        {% endfor %}
+        <div class="flex justify-end">
+            <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+        </div>
+    </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul admin base layout for Tailwind-powered dark mode
- restyle emission, quote, client and program screens with dark tables and forms
- align cotação form styling with emissão form in dark theme

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e6e6b4fac8327b6a487d267473f3c