### PR TITLE
Padroniza formulários de emissão e cotação

### DIFF
--- a/gestao/forms.py
+++ b/gestao/forms.py
@@ -112,6 +112,8 @@ class EmissaoHotelForm(forms.ModelForm):
 
 
 class CotacaoVooForm(forms.ModelForm):
+    qtd_escalas = forms.IntegerField(min_value=0, required=False, initial=0)
+
     class Meta:
         model = CotacaoVoo
         fields = [

--- a/gestao/templates/admin_custom/cotacoes_voo_form.html
+++ b/gestao/templates/admin_custom/cotacoes_voo_form.html
@@ -2,22 +2,224 @@
 {% block title %}Nova Cotação de Voo{% endblock %}
 {% block header_title %}Nova Cotação de Voo{% endblock %}
 {% block menu_cotacoes_voo %}bg-zinc-700 text-white{% endblock %}
-{% block content %}
-<div class="max-w-xl mx-auto">
-    <form method="post" class="bg-zinc-800 p-6 rounded-xl space-y-4">
-        {% csrf_token %}
-        {% for field in form %}
-        <div>
-            <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
-            {{ field }}
-            {% if field.errors %}
-            <div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>
-            {% endif %}
-        </div>
-        {% endfor %}
-        <div class="flex justify-end">
-            <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
-        </div>
-    </form>
-</div>
+
+{% block extra_head %}
+<style>
+body {
+  background: #18181b;
+  color: #f4f4f5;
+  font-family: 'Inter', Arial, sans-serif;
+}
+.content {
+  background: #18181b;
+}
+.form-card {
+  background: #27272a;
+  border: 1px solid #3f3f46;
+  border-radius: 16px;
+  box-shadow: 0 2px 16px rgba(0,0,0,0.2);
+  padding: 32px 40px;
+  max-width: 520px;
+  width: 100%;
+  margin: 0 auto;
+}
+.form-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #f4f4f5;
+  margin-bottom: 24px;
+  text-align: center;
+}
+.section-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #e4e4e7;
+  margin: 26px 0 12px 0;
+}
+.form-group {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+.form-group.single {
+  display: block;
+  margin-bottom: 12px;
+}
+.form-label {
+  font-size: 1rem;
+  color: #e4e4e7;
+  font-weight: 500;
+  display: block;
+  margin-bottom: 6px;
+}
+.form-card input,
+.form-card select,
+.form-card textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  background: #18181b;
+  color: #f4f4f5;
+  font-size: 1rem;
+  margin-bottom: 2px;
+  transition: border 0.2s;
+}
+.form-card input:focus,
+.form-card select:focus,
+.form-card textarea:focus {
+  border-color: #7c3aed;
+  outline: none;
+}
+.form-card textarea {
+  min-height: 60px;
+  resize: vertical;
+}
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 22px;
+}
+.btn-primary {
+  background: #6d28d9;
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 32px;
+  cursor: pointer;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  transition: background 0.18s;
+}
+.btn-primary:hover {
+  background: #7c3aed;
+}
+</style>
 {% endblock %}
+
+{% block content %}
+<form method="post" class="form-card">
+    {% csrf_token %}
+    <div class="form-title">Formulário de Cotação de Viagem</div>
+
+    <div class="section-title">Informações Básicas</div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.cliente.id_for_label }}">Cliente</label>
+            {{ form.cliente }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.programa.id_for_label }}">Programa</label>
+            {{ form.programa }}
+        </div>
+    </div>
+
+    <div class="section-title">Detalhes do Voo</div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.origem.id_for_label }}">Aeroporto partida</label>
+            {{ form.origem }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.destino.id_for_label }}">Aeroporto destino</label>
+            {{ form.destino }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.data_ida.id_for_label }}">Data ida</label>
+            {{ form.data_ida }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.data_volta.id_for_label }}">Data volta</label>
+            {{ form.data_volta }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.qtd_passageiros.id_for_label }}">Quantidade de passageiros</label>
+            {{ form.qtd_passageiros }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.classe.id_for_label }}">Classe</label>
+            {{ form.classe }}
+        </div>
+    </div>
+
+    <div class="section-title">Escalas</div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.qtd_escalas.id_for_label }}">Quantidade de escalas</label>
+            {{ form.qtd_escalas }}
+        </div>
+    </div>
+
+    <div class="section-title">Companhia Aérea</div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.companhia_aerea.id_for_label }}">Companhia aérea</label>
+            {{ form.companhia_aerea }}
+        </div>
+    </div>
+
+    <div class="section-title">Outras Informações</div>
+    <div class="form-group single">
+        <label class="form-label" for="{{ form.observacoes.id_for_label }}">Observações</label>
+        {{ form.observacoes }}
+    </div>
+
+    <div class="section-title">Valores Financeiros</div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.valor_passagem.id_for_label }}">Valor passagem (R$)</label>
+            {{ form.valor_passagem }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.taxas.id_for_label }}">Taxas (R$)</label>
+            {{ form.taxas }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.milhas.id_for_label }}">Milhas</label>
+            {{ form.milhas }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.valor_milheiro.id_for_label }}">Valor milheiro (R$)</label>
+            {{ form.valor_milheiro }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.parcelas.id_for_label }}">Número de parcelas sem juros</label>
+            {{ form.parcelas }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.juros.id_for_label }}">Juros (%)</label>
+            {{ form.juros }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.desconto.id_for_label }}">Desconto (%)</label>
+            {{ form.desconto }}
+        </div>
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.validade.id_for_label }}">Validade</label>
+            {{ form.validade }}
+        </div>
+    </div>
+    <div class="form-group">
+        <div style="flex: 1;">
+            <label class="form-label" for="{{ form.status.id_for_label }}">Status</label>
+            {{ form.status }}
+        </div>
+    </div>
+
+    <div class="form-actions">
+        <button class="btn-primary" type="submit">Salvar</button>
+    </div>
+</form>
+{% endblock %}
+

--- a/gestao/templates/admin_custom/emissoes_form.html
+++ b/gestao/templates/admin_custom/emissoes_form.html
@@ -27,6 +27,7 @@ body {
   padding: 32px 40px;
   max-width: 520px;
   width: 100%;
+  margin: 0 auto;
 }
 .form-title {
   font-size: 2.2rem;
@@ -235,41 +236,6 @@ body {
     </div>
 </form>
 
-{% if emissoes %}
-<div class="form-card" style="margin-top:24px;">
-    <div class="section-title">Emissões já realizadas</div>
-    <div style="overflow-x:auto;">
-        <table class="existing-table">
-            <thead>
-                <tr>
-                    <th>Cliente</th>
-                    <th>Programa</th>
-                    <th>Origem</th>
-                    <th>Destino</th>
-                    <th>Data Ida</th>
-                    <th>Data Volta</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for e in emissoes %}
-                <tr>
-                    <td>{{ e.cliente.usuario.get_full_name|default:e.cliente.usuario.username }}</td>
-                    <td>{{ e.programa }}</td>
-                    <td>{{ e.aeroporto_partida }}</td>
-                    <td>{{ e.aeroporto_destino }}</td>
-                    <td>{{ e.data_ida|date:"d/m/Y H:i" }}</td>
-                    <td>{{ e.data_volta|date:"d/m/Y H:i" }}</td>
-                    <td><a href="{% url 'admin_editar_emissao' e.id %}" class="text-violet-400">Editar</a></td>
-                </tr>
-                {% empty %}
-                <tr><td colspan="7">Nenhuma emissão encontrada.</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-</div>
-{% endif %}
 <script>
 const passageirosData = {{ passageiros_json|safe }};
 const escalasData = {{ escalas_json|safe }};


### PR DESCRIPTION
## Sumário
- centraliza formulário de nova emissão
- padroniza visual dos formulários de emissão e cotação
- remove listagem de emissões existentes

## Testes
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e7330b8b88327b0a1ed97d380d3fb