### PR TITLE
Admin dashboard client filter and metrics API

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -21,6 +21,7 @@ from gestao import views
 urlpatterns = [
     path('admin/', admin.site.urls),          # Django admin padrão
     path('adm/', include('gestao.urls_admin')),  # Painel admin customizado
+    path('api/dashboard', views.api_dashboard, name='api_dashboard'),
     path('', include('painel_cliente.urls')),    # Painel do cliente comum
     path('adm/programas/', views.admin_programas, name='admin_programas'),
     path('adm/valor-milheiro/', views.admin_valor_milheiro, name='admin_valor_milheiro'),

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -2,67 +2,106 @@
 {% block title %}Dashboard{% endblock %}
 {% block header_title %}Dashboard Administrativo{% endblock %}
 {% block menu_dashboard %}bg-zinc-700 text-white{% endblock %}
-{% block content %}
-    <div class="row">
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Total Clientes</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">{{ total_clientes }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Contas Fidelidade</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">{{ total_contas }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Emissões</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">{{ total_emissoes }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Pontos (total)</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">{{ total_pontos }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Reservas de Hotéis</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">{{ total_hoteis }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3 mb-3">
-            <div class="card bg-dark text-light">
-                <div class="card-body">
-                    <h5 class="card-title">Valor em Hotéis</h5>
-                    <p class="card-text" style="font-size:2.2rem;font-weight:700;">R$ {{ valor_hoteis|floatformat:2 }}</p>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="mt-4" style="background:#232345;border-radius:12px;padding:16px;">
-        <h4 style="color:#b6a9ff;">Cotações do Milheiro</h4>
-        <ul style="margin:0;padding:0;list-style:none;">
-            {% for cotacao in cotacoes_mercado %}
-                <li>
-                    <strong>{{ cotacao.programa_nome }}</strong>: R$ {{ cotacao.valor_mercado|floatformat:2 }}
-                </li>
-            {% empty %}
-                <li><i>Nenhuma cotação cadastrada.</i></li>
-            {% endfor %}
-        </ul>
-    </div>
+{% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 {% endblock %}
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+    <select id="clienteSelect" class="bg-zinc-700 text-white px-3 py-2 rounded">
+        <option value="">Selecionar Cliente</option>
+        {% for c in clientes %}
+            <option value="{{ c.id }}" {% if selected_cliente and c.id == selected_cliente.id %}selected{% endif %}>{{ c }}</option>
+        {% endfor %}
+    </select>
+    <a id="novaEmissaoBtn" href="{% url 'admin_nova_emissao' %}{% if selected_cliente %}?cliente_id={{ selected_cliente.id }}{% endif %}" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded font-bold">+ Nova Emissão</a>
+</div>
+
+<div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 mb-6">
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <div class="text-sm text-zinc-400">👥 Total de Clientes</div>
+        <div class="text-2xl font-bold">{{ total_clientes }}</div>
+    </div>
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <div class="text-sm text-zinc-400">✈️ Total de Emissões</div>
+        <div class="text-2xl font-bold">{{ total_emissoes }}</div>
+    </div>
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <div class="text-sm text-zinc-400">💳 Total de Pontos</div>
+        <div class="text-2xl font-bold">{{ total_pontos }}</div>
+    </div>
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <div class="text-sm text-zinc-400">💰 Total Economizado</div>
+        <div class="text-2xl font-bold">R$ {{ total_economizado|floatformat:2 }}</div>
+    </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6">
+{% for prog in programas %}
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <h5 class="text-violet-300 font-bold mb-2">{{ prog.nome }}</h5>
+        <p class="text-sm text-zinc-400">Pontos acumulados</p>
+        <p class="font-bold">{{ prog.pontos }}</p>
+        <p class="text-sm text-zinc-400 mt-2">Valor total</p>
+        <p class="font-bold">R$ {{ prog.valor_total|floatformat:2 }}</p>
+        <p class="text-sm text-zinc-400 mt-2">Valor médio por 1.000</p>
+        <p class="font-bold">R$ {{ prog.valor_medio|floatformat:2 }}</p>
+        <p class="text-sm text-zinc-400 mt-2">Valor de referência atual</p>
+        <p class="font-bold">R$ {{ prog.valor_referencia|floatformat:2 }}</p>
+        {% if prog.conta_id %}
+        <a href="{% url 'admin_movimentacoes' prog.conta_id %}" class="mt-4 inline-block bg-violet-700 hover:bg-violet-600 text-white px-3 py-1 rounded">Ver movimentações</a>
+        {% endif %}
+    </div>
+{% empty %}
+    <p>Nenhum programa encontrado.</p>
+{% endfor %}
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <h5 class="text-violet-300 font-bold mb-2">Emissões</h5>
+        <ul class="text-sm space-y-1">
+            <li>Quantidade: <span class="font-bold">{{ emissoes.qtd }}</span></li>
+            <li>Total de pontos usados: <span class="font-bold">{{ emissoes.pontos }}</span></li>
+            <li>Valor total de referência: <span class="font-bold">R$ {{ emissoes.valor_referencia|floatformat:2 }}</span></li>
+            <li>Valor total pago: <span class="font-bold">R$ {{ emissoes.valor_pago|floatformat:2 }}</span></li>
+            <li>Valor total economizado: <span class="font-bold">R$ {{ emissoes.valor_economizado|floatformat:2 }}</span></li>
+        </ul>
+        <a href="{% url 'admin_emissoes' %}" class="mt-4 inline-block bg-violet-700 hover:bg-violet-600 text-white px-3 py-1 rounded">Ver detalhes</a>
+    </div>
+    <div class="bg-zinc-900 p-4 rounded shadow">
+        <h5 class="text-violet-300 font-bold mb-2">Hotéis</h5>
+        <ul class="text-sm space-y-1">
+            <li>Quantidade de reservas: <span class="font-bold">{{ hoteis.qtd }}</span></li>
+            <li>Valor de referência acumulado: <span class="font-bold">R$ {{ hoteis.valor_referencia|floatformat:2 }}</span></li>
+            <li>Valor total pago: <span class="font-bold">R$ {{ hoteis.valor_pago|floatformat:2 }}</span></li>
+            <li>Valor total economizado: <span class="font-bold">R$ {{ hoteis.valor_economizado|floatformat:2 }}</span></li>
+        </ul>
+        <a href="{% url 'admin_hoteis' %}" class="mt-4 inline-block bg-violet-700 hover:bg-violet-600 text-white px-3 py-1 rounded">Ver detalhes</a>
+    </div>
+</div>
+
+<div class="bg-zinc-900 p-4 rounded shadow">
+    <h5 class="text-violet-300 font-bold mb-2">Emissões por programa</h5>
+    <canvas id="emissoesChart"></canvas>
+</div>
+{% endblock %}
+{% block extra_body %}
+<script>
+document.getElementById('clienteSelect').addEventListener('change', function() {
+    const value = this.value;
+    const url = '{% url "admin_dashboard" %}';
+    window.location = value ? url + '?cliente_id=' + value : url;
+});
+const ctx = document.getElementById('emissoesChart');
+const chartData = {
+    labels: [{% for item in emissoes_programa %}'{{ item.programa }}',{% endfor %}],
+    datasets: [{
+        label: 'Emissões',
+        data: [{% for item in emissoes_programa %}{{ item.quantidade }},{% endfor %}],
+        backgroundColor: '#7c3aed'
+    }]
+};
+new Chart(ctx, {type: 'bar', data: chartData, options: {scales: {y: {beginAtZero: true}}}});
+</script>
+{% endblock %}
+

--- a/gestao/views/emissoes.py
+++ b/gestao/views/emissoes.py
@@ -130,6 +130,7 @@ def admin_emissoes(request):
 @login_required
 @user_passes_test(admin_required)
 def nova_emissao(request):
+    cliente_id = request.GET.get("cliente_id")
     if request.method == "POST":
         form = EmissaoPassagemForm(request.POST)
         if form.is_valid():
@@ -163,7 +164,8 @@ def nova_emissao(request):
                     )
             return redirect("admin_emissoes")
     else:
-        form = EmissaoPassagemForm()
+        initial = {"cliente": cliente_id} if cliente_id else {}
+        form = EmissaoPassagemForm(initial=initial)
     emissoes = EmissaoPassagem.objects.all().order_by("-data_ida")
     aeroportos = list(Aeroporto.objects.values("id", "nome", "sigla"))
     return render(
@@ -175,6 +177,7 @@ def nova_emissao(request):
             "passageiros_json": "[]",
             "escalas_json": "[]",
             "aeroportos_json": json.dumps(aeroportos),
+            "cliente_id": cliente_id,
         },
     )
 


### PR DESCRIPTION
## Summary
- add helper to compute dashboard metrics and API endpoint for optional client scope
- redesign admin dashboard with client filter, summary cards, and Chart.js graph
- preselect client when creating a new emission via query parameter

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e78191a2883279834a7f28c34e4fb