### PR TITLE
Refine client registration form layout

### DIFF
--- a/gestao/static/gestao/formulario_cliente.css
+++ b/gestao/static/gestao/formulario_cliente.css
@@ -1,0 +1,103 @@
+.form-wrapper {
+  max-width: 900px;
+  width: 90%;
+  margin: 40px auto;
+  padding: 30px;
+  background: #27272a;
+  border: 1px solid #3f3f46;
+  border-radius: 16px;
+  box-shadow: 0 2px 16px rgba(0,0,0,0.2);
+}
+
+.form-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #f4f4f5;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.section-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #e4e4e7;
+  margin: 26px 0 12px 0;
+}
+
+.form-group {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.form-group.single {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.form-group > div {
+  flex: 1;
+}
+
+@media (max-width: 640px) {
+  .form-group {
+    flex-direction: column;
+  }
+}
+
+.form-label {
+  font-size: 1rem;
+  color: #e4e4e7;
+  font-weight: 500;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.form-wrapper input,
+.form-wrapper select,
+.form-wrapper textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  background: #18181b;
+  color: #f4f4f5;
+  font-size: 1rem;
+  margin-bottom: 2px;
+  transition: border 0.2s;
+}
+
+.form-wrapper input:focus,
+.form-wrapper select:focus,
+.form-wrapper textarea:focus {
+  border-color: #7c3aed;
+  outline: none;
+}
+
+.form-wrapper textarea {
+  min-height: 60px;
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 22px;
+}
+
+.btn-primary {
+  background: #6d28d9;
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 32px;
+  cursor: pointer;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  transition: background 0.18s;
+}
+
+.btn-primary:hover {
+  background: #7c3aed;
+}

--- a/gestao/templates/admin_custom/cliente_form.html
+++ b/gestao/templates/admin_custom/cliente_form.html
@@ -4,102 +4,12 @@
 {% block menu_clientes %}bg-zinc-700 text-white{% endblock %}
 
 {% block extra_head %}
-<style>
-body {
-  background: #18181b;
-  color: #f4f4f5;
-  font-family: 'Inter', Arial, sans-serif;
-}
-.content {
-  background: #18181b;
-}
-.form-card {
-  background: #27272a;
-  border: 1px solid #3f3f46;
-  border-radius: 16px;
-  box-shadow: 0 2px 16px rgba(0,0,0,0.2);
-  padding: 32px 40px;
-  max-width: 520px;
-  width: 100%;
-  margin: 0 auto;
-}
-.form-title {
-  font-size: 2.2rem;
-  font-weight: 700;
-  color: #f4f4f5;
-  margin-bottom: 24px;
-  text-align: center;
-}
-.section-title {
-  font-size: 1.15rem;
-  font-weight: 600;
-  color: #e4e4e7;
-  margin: 26px 0 12px 0;
-}
-.form-group {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 12px;
-}
-.form-group.single {
-  display: block;
-  margin-bottom: 12px;
-}
-.form-label {
-  font-size: 1rem;
-  color: #e4e4e7;
-  font-weight: 500;
-  display: block;
-  margin-bottom: 6px;
-}
-.form-card input,
-.form-card select,
-.form-card textarea {
-  width: 100%;
-  padding: 10px 14px;
-  border: 1px solid #3f3f46;
-  border-radius: 8px;
-  background: #18181b;
-  color: #f4f4f5;
-  font-size: 1rem;
-  margin-bottom: 2px;
-  transition: border 0.2s;
-}
-.form-card input:focus,
-.form-card select:focus,
-.form-card textarea:focus {
-  border-color: #7c3aed;
-  outline: none;
-}
-.form-card textarea {
-  min-height: 60px;
-  resize: vertical;
-}
-.form-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 22px;
-}
-.btn-primary {
-  background: #6d28d9;
-  color: #fff;
-  font-weight: 600;
-  border: none;
-  border-radius: 8px;
-  padding: 12px 32px;
-  cursor: pointer;
-  font-size: 1rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-  transition: background 0.18s;
-}
-.btn-primary:hover {
-  background: #7c3aed;
-}
-</style>
+<link rel="stylesheet" href="{% static 'gestao/formulario_cliente.css' %}">
 {% endblock %}
 
 {% block content %}
-<form method="post" class="form-card">
+<div class="form-wrapper">
+<form method="post">
     {% csrf_token %}
     <div class="form-title">Cadastro de Cliente</div>
     {% if form.username %}
@@ -175,4 +85,5 @@ body {
         <button type="submit" class="btn-primary">Salvar</button>
     </div>
 </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract customer form styles into a dedicated CSS file
- wrap form with `.form-wrapper` and apply responsive layout

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e8495969c8327b063e0fc0d09726d