### PR TITLE
Padroniza formulários e cria seção de dados complementares

### DIFF
--- a/gestao/static/gestao/formulario_base_gestao.css
+++ b/gestao/static/gestao/formulario_base_gestao.css
@@ -47,7 +47,7 @@
 
 .form-label {
   font-size: 1rem;
-  color: #d1c1f7;
+  color: #2E8B57;
   font-weight: 500;
   display: block;
   margin-bottom: 6px;
@@ -70,7 +70,7 @@
 .form-wrapper input:focus,
 .form-wrapper select:focus,
 .form-wrapper textarea:focus {
-  border-color: #7c3aed;
+  border-color: #2E8B57;
   outline: none;
 }
 
@@ -86,8 +86,8 @@
 }
 
 .btn-primary {
-  background: linear-gradient(90deg, #b67cff, #6c47cf);
-  color: #fff;
+  background: linear-gradient(90deg, #D1863F, #BFA45F);
+  color: #f6f6f6;
   font-weight: 600;
   border: none;
   border-radius: 8px;
@@ -95,9 +95,9 @@
   cursor: pointer;
   font-size: 1rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  transition: background 0.18s;
+  transition: opacity 0.18s;
 }
 
 .btn-primary:hover {
-  background: linear-gradient(90deg, #6c47cf, #b67cff);
+  opacity: 0.9;
 }

--- a/gestao/templates/admin_custom/aeroportos.html
+++ b/gestao/templates/admin_custom/aeroportos.html
@@ -2,18 +2,26 @@
 {% block title %}Aeroportos{% endblock %}
 {% block header_title %}Aeroportos{% endblock %}
 {% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
+{% endblock %}
 {% block content %}
-<form method="post" class="bg-zinc-800 p-4 rounded-xl mb-6 space-y-4 max-w-xl">
+<div class="form-wrapper mb-6">
+<form method="post">
     {% csrf_token %}
+    <div class="form-title">Adicionar Aeroporto</div>
     {% for field in form %}
-    <div>
-        <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+    <div class="form-group single">
+        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
         {{ field }}
         {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
     </div>
     {% endfor %}
-    <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Salvar</button>
+    </div>
 </form>
+</div>
 <div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
     <table class="min-w-full text-sm">
         <thead class="bg-zinc-700 text-zinc-200">

--- a/gestao/templates/admin_custom/contas_form.html
+++ b/gestao/templates/admin_custom/contas_form.html
@@ -1,8 +1,27 @@
-{% extends 'admin_custom/base_admin.html' %}
-{% block content %}
-<h2>Nova Conta Fidelidade</h2>
-<form method="post">{% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn btn-primary">Salvar</button>
-</form>
+{% extends "admin_custom/base_admin.html" %}
+{% load static %}
+{% block title %}{% if form.instance.pk %}Editar Conta Fidelidade{% else %}Nova Conta Fidelidade{% endif %}{% endblock %}
+{% block header_title %}{% if form.instance.pk %}Editar Conta Fidelidade{% else %}Nova Conta Fidelidade{% endif %}{% endblock %}
+{% block menu_contas %}bg-zinc-700 text-white{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
+{% block content %}
+<div class="form-wrapper">
+<form method="post">
+    {% csrf_token %}
+    <div class="form-title">{% if form.instance.pk %}Editar Conta Fidelidade{% else %}Nova Conta Fidelidade{% endif %}</div>
+    {% for field in form %}
+    <div class="form-group single">
+        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {{ field }}
+        {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
+    </div>
+    {% endfor %}
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Salvar</button>
+    </div>
+</form>
+</div>
+{% endblock %}
+

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -19,6 +19,21 @@
     </div>
 </div>
 
+<div class="mb-6">
+    <h3 class="text-zinc-200 font-semibold mb-2">Dados Complementares</h3>
+    <div class="flex flex-wrap gap-3">
+        <a href="{% url 'admin_programas' %}"
+           class="px-4 py-2 rounded font-bold"
+           style="background:linear-gradient(90deg,#D1863F,#BFA45F);color:#f6f6f6;">+ Adicionar Programa</a>
+        <a href="{% url 'admin_nova_companhia' %}"
+           class="px-4 py-2 rounded font-bold"
+           style="background:linear-gradient(90deg,#D1863F,#BFA45F);color:#f6f6f6;">+ Adicionar Companhia Aérea</a>
+        <a href="{% url 'admin_aeroportos' %}"
+           class="px-4 py-2 rounded font-bold"
+           style="background:linear-gradient(90deg,#D1863F,#BFA45F);color:#f6f6f6;">+ Adicionar Aeroporto</a>
+    </div>
+</div>
+
 <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 mb-6">
     <div class="bg-zinc-900 p-4 rounded shadow">
         <div class="text-sm text-zinc-400">👥 Total de Clientes</div>

--- a/gestao/templates/admin_custom/form_aeroporto.html
+++ b/gestao/templates/admin_custom/form_aeroporto.html
@@ -4,7 +4,7 @@
 {% block header_title %}{% if form.instance.pk %}Editar Aeroporto{% else %}Novo Aeroporto{% endif %}{% endblock %}
 {% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/form_cliente.html
+++ b/gestao/templates/admin_custom/form_cliente.html
@@ -6,7 +6,7 @@
 {% block menu_clientes %}bg-zinc-700 text-white{% endblock %}
 
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/gestao/templates/admin_custom/form_companhia_aerea.html
+++ b/gestao/templates/admin_custom/form_companhia_aerea.html
@@ -4,7 +4,7 @@
 {% block header_title %}Companhias Aéreas{% endblock %}
 {% block menu_companhias %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/form_cotacao.html
+++ b/gestao/templates/admin_custom/form_cotacao.html
@@ -4,7 +4,7 @@
 {% block header_title %}{% if form.instance.pk %}Editar Cotação{% else %}Nova Cotação de Voo{% endif %}{% endblock %}
 {% block menu_cotacoes_voo %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -4,7 +4,7 @@
 {% block header_title %}{% if form.instance.pk %}Editar Emissão{% else %}Nova Emissão{% endif %}{% endblock %}
 {% block menu_emissoes %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/form_hotel.html
+++ b/gestao/templates/admin_custom/form_hotel.html
@@ -4,7 +4,7 @@
 {% block header_title %}{% if form.instance.pk %}Editar Emissão de Hotel{% else %}Nova Emissão de Hotel{% endif %}{% endblock %}
 {% block menu_hoteis %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/form_programa.html
+++ b/gestao/templates/admin_custom/form_programa.html
@@ -4,7 +4,7 @@
 {% block header_title %}{% if form.instance.pk %}Editar Programa{% else %}Novo Programa{% endif %}{% endblock %}
 {% block menu_programas %}bg-zinc-700 text-white{% endblock %}
 {% block extra_head %}
-<link rel="stylesheet" href="{% static 'gestao/formularios_base_gestao.css' %}">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}
 {% block content %}
 <div class="form-wrapper">

--- a/gestao/templates/admin_custom/programas.html
+++ b/gestao/templates/admin_custom/programas.html
@@ -2,20 +2,26 @@
 {% block title %}Programas{% endblock %}
 {% block header_title %}Programas de Pontos{% endblock %}
 {% block menu_programas %}bg-zinc-700 text-white{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
+{% endblock %}
 {% block content %}
-<form method="post" class="bg-zinc-800 p-4 rounded-xl mb-6 space-y-4 max-w-xl">
+<div class="form-wrapper mb-6">
+<form method="post">
     {% csrf_token %}
+    <div class="form-title">Adicionar Programa</div>
     {% for field in form %}
-    <div>
-        <label class="block mb-1 text-sm text-zinc-300">{{ field.label }}</label>
+    <div class="form-group single">
+        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
         {{ field }}
-        {% if field.errors %}
-        <div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>
-        {% endif %}
+        {% if field.errors %}<div class="text-red-400 text-sm mt-1">{{ field.errors }}</div>{% endif %}
     </div>
     {% endfor %}
-    <button type="submit" class="bg-violet-700 hover:bg-violet-600 text-white px-4 py-2 rounded">Salvar</button>
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Salvar</button>
+    </div>
 </form>
+</div>
 
 <div class="bg-zinc-800 rounded-xl p-4 overflow-x-auto">
     <table class="min-w-full text-sm">


### PR DESCRIPTION
## Summary
- centraliza CSS base para formulários
- aplica layout unificado à conta fidelidade e aos cadastros de programa e aeroporto
- adiciona seção "Dados Complementares" no dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e954a58108327b9cff575d706a59a