### PR TITLE
Keep Dados Complementares open and fix delete permissions

### DIFF
--- a/gestao/templates/admin_custom/aeroportos.html
+++ b/gestao/templates/admin_custom/aeroportos.html
@@ -2,6 +2,7 @@
 {% block title %}Aeroportos{% endblock %}
 {% block header_title %}Aeroportos{% endblock %}
 {% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block content %}
 <div class="flex justify-between items-center mb-6 flex-wrap gap-4">
     <form method="get" class="flex gap-3">

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -23,7 +23,7 @@
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_calculadora %}{% endblock %}" href="{% url 'admin_calculadora_cotacao' %}">Calculadora</a>
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_auditoria %}{% endblock %}" href="{% url 'admin_auditoria' %}">Auditoria</a>
-            <details class="pt-4 group">
+            <details class="pt-4 group" {% block dados_complementares_open %}{% endblock %}>
                 <summary class="px-3 py-2 rounded text-blue-400 cursor-pointer hover:bg-zinc-700 focus:outline-none">Dados Complementares</summary>
                 <div class="mt-2 ml-4 flex flex-col space-y-2">
                     <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_aeroportos %}{% endblock %}" href="{% url 'admin_aeroportos' %}">Aeroporto</a>
@@ -42,6 +42,15 @@
                 <a href="{% url 'logout' %}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Logout</a>
             </div>
         </header>
+        {% if messages %}
+        <div class="mb-4 space-y-2">
+            {% for message in messages %}
+            <div class="p-3 rounded text-white {% if 'success' in message.tags %}bg-green-600{% else %}bg-red-600{% endif %}">
+                {{ message }}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
         <section class="bg-zinc-800 rounded-xl shadow p-6">
             {% block content %}{% endblock %}
         </section>

--- a/gestao/templates/admin_custom/companhias.html
+++ b/gestao/templates/admin_custom/companhias.html
@@ -2,6 +2,7 @@
 {% block title %}Companhias Aéreas{% endblock %}
 {% block header_title %}Companhias Aéreas{% endblock %}
 {% block menu_companhias %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block content %}
 <div class="flex justify-between items-center mb-6 flex-wrap gap-4">
   <form method="get" class="flex gap-3">

--- a/gestao/templates/admin_custom/form_aeroporto.html
+++ b/gestao/templates/admin_custom/form_aeroporto.html
@@ -3,6 +3,7 @@
 {% block title %}{% if form.instance.pk %}Editar Aeroporto{% else %}Novo Aeroporto{% endif %}{% endblock %}
 {% block header_title %}{% if form.instance.pk %}Editar Aeroporto{% else %}Novo Aeroporto{% endif %}{% endblock %}
 {% block menu_aeroportos %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}

--- a/gestao/templates/admin_custom/form_companhia_aerea.html
+++ b/gestao/templates/admin_custom/form_companhia_aerea.html
@@ -3,6 +3,7 @@
 {% block title %}{% if form.instance.pk %}Editar Companhia{% else %}Nova Companhia{% endif %}{% endblock %}
 {% block header_title %}Companhias Aéreas{% endblock %}
 {% block menu_companhias %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}

--- a/gestao/templates/admin_custom/form_programa.html
+++ b/gestao/templates/admin_custom/form_programa.html
@@ -3,6 +3,7 @@
 {% block title %}{% if form.instance.pk %}Editar Programa{% else %}Novo Programa{% endif %}{% endblock %}
 {% block header_title %}{% if form.instance.pk %}Editar Programa{% else %}Novo Programa{% endif %}{% endblock %}
 {% block menu_programas %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 {% endblock %}

--- a/gestao/templates/admin_custom/programas.html
+++ b/gestao/templates/admin_custom/programas.html
@@ -2,6 +2,7 @@
 {% block title %}Programas{% endblock %}
 {% block header_title %}Programas de Pontos{% endblock %}
 {% block menu_programas %}bg-zinc-700 text-white{% endblock %}
+{% block dados_complementares_open %}open{% endblock %}
 {% block content %}
 <div class="flex justify-between items-center mb-6 flex-wrap gap-4">
     <form method="get" class="flex gap-3">

--- a/gestao/views/companhias.py
+++ b/gestao/views/companhias.py
@@ -1,8 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q
-from django.http import HttpResponse
+from django.contrib import messages
 
 from ..forms import (
     ContaFidelidadeForm,
@@ -83,7 +82,9 @@ def editar_companhia(request, companhia_id):
 
 @login_required
 def deletar_companhia(request, companhia_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    CompanhiaAerea.objects.filter(id=companhia_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        CompanhiaAerea.objects.filter(id=companhia_id).delete()
+        messages.success(request, "Companhia aérea deletada com sucesso.")
     return redirect("admin_companhias")

--- a/gestao/views/cotacoes.py
+++ b/gestao/views/cotacoes.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import HttpResponse
+from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from gestao.models import ContaFidelidade, Movimentacao, AcessoClienteLog
 from painel_cliente.views import build_dashboard_context
@@ -76,9 +77,11 @@ def admin_cotacoes(request):
 
 @login_required
 def deletar_cotacao(request, cotacao_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    ValorMilheiro.objects.filter(id=cotacao_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        ValorMilheiro.objects.filter(id=cotacao_id).delete()
+        messages.success(request, "Cotação deletada com sucesso.")
     return redirect("admin_cotacoes")
 
 
@@ -176,9 +179,11 @@ def editar_cotacao_voo(request, cotacao_id):
 
 @login_required
 def deletar_cotacao_voo(request, cotacao_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    CotacaoVoo.objects.filter(id=cotacao_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        CotacaoVoo.objects.filter(id=cotacao_id).delete()
+        messages.success(request, "Cotação de voo deletada com sucesso.")
     return redirect("admin_cotacoes_voo")
 
 @login_required

--- a/gestao/views/emissoes.py
+++ b/gestao/views/emissoes.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import HttpResponse
+from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from gestao.models import ContaFidelidade, Movimentacao, AcessoClienteLog
 from painel_cliente.views import build_dashboard_context
@@ -264,9 +265,11 @@ def emissao_pdf(request, emissao_id):
 
 @login_required
 def deletar_emissao(request, emissao_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    EmissaoPassagem.objects.filter(id=emissao_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        EmissaoPassagem.objects.filter(id=emissao_id).delete()
+        messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_emissoes")
 
 
@@ -321,9 +324,11 @@ def editar_emissao_hotel(request, emissao_id):
 
 @login_required
 def deletar_emissao_hotel(request, emissao_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    EmissaoHotel.objects.filter(id=emissao_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        EmissaoHotel.objects.filter(id=emissao_id).delete()
+        messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_hoteis")
 
 

--- a/gestao/views/programas.py
+++ b/gestao/views/programas.py
@@ -1,9 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.contrib.auth.decorators import login_required, user_passes_test
-from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q
-from django.http import HttpResponse
+from django.contrib import messages
 
 from ..forms import (
     ContaFidelidadeForm,
@@ -84,9 +82,11 @@ def editar_programa(request, programa_id):
 
 @login_required
 def deletar_programa(request, programa_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    ProgramaFidelidade.objects.filter(id=programa_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        ProgramaFidelidade.objects.filter(id=programa_id).delete()
+        messages.success(request, "Programa deletado com sucesso.")
     return redirect("admin_programas")
 
 

--- a/gestao/views/utils.py
+++ b/gestao/views/utils.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.paginator import Paginator
 from django.db.models import Q, Count
 from django.http import HttpResponse, JsonResponse
+from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from gestao.models import ContaFidelidade, Movimentacao, AcessoClienteLog
 from painel_cliente.views import build_dashboard_context
@@ -83,9 +84,11 @@ def editar_conta(request, conta_id):
 
 @login_required
 def deletar_conta(request, conta_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    ContaFidelidade.objects.filter(id=conta_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        ContaFidelidade.objects.filter(id=conta_id).delete()
+        messages.success(request, "Conta deletada com sucesso.")
     return redirect("admin_contas")
 
 
@@ -145,9 +148,11 @@ def criar_aeroporto(request):
 
 @login_required
 def deletar_aeroporto(request, aeroporto_id):
-    if not getattr(request.user, "cliente_gestao", None) or request.user.cliente_gestao.perfil != "admin":
-        return HttpResponse("Você não tem permissão para deletar este item")
-    Aeroporto.objects.filter(id=aeroporto_id).delete()
+    if not (request.user.is_staff or request.user.is_superuser):
+        messages.error(request, "Você não tem autorização para deletar este item.")
+    else:
+        Aeroporto.objects.filter(id=aeroporto_id).delete()
+        messages.success(request, "Aeroporto deletado com sucesso.")
     return redirect("admin_aeroportos")
 
 


### PR DESCRIPTION
## Summary
- keep Dados Complementares section expanded when browsing its pages
- allow admins to delete records and show warning to unauthorized users

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688eaa1d5ed88327b854410e4d412b55