### PR TITLE
Implement role-based access checks and add user management link

### DIFF
--- a/accounts/templates/accounts/user_form.html
+++ b/accounts/templates/accounts/user_form.html
@@ -6,23 +6,19 @@
 </head>
 <body>
     <h2>Criar Usuário</h2>
-    {% if sem_permissao %}
-        <p style="color:red;">Você não tem autorização para acessar esta funcionalidade.</p>
-    {% else %}
-        {% if messages %}
-          <ul>
-            {% for message in messages %}
-              <li style="color:green">{{ message }}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-        {% if form %}
-        <form method="POST">
-            {% csrf_token %}
-            {{ form.as_p }}
-            <button type="submit">Salvar</button>
-        </form>
-        {% endif %}
+    {% if messages %}
+      <ul>
+        {% for message in messages %}
+          <li style="color:green">{{ message }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if form %}
+    <form method="POST">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Salvar</button>
+    </form>
     {% endif %}
 </body>
 </html>

--- a/accounts/templates/accounts/user_list.html
+++ b/accounts/templates/accounts/user_list.html
@@ -6,17 +6,13 @@
 </head>
 <body>
     <h2>Usuários</h2>
-    {% if sem_permissao %}
-        <p style="color:red;">Você não tem autorização para acessar esta funcionalidade.</p>
-    {% else %}
-        <a href="{% url 'user_create' %}">Novo Usuário</a>
-        <ul>
-            {% for u in usuarios %}
-                <li>{{ u.usuario.username }} - {{ u.get_perfil_display }}</li>
-            {% empty %}
-                <li>Nenhum usuário cadastrado.</li>
-            {% endfor %}
-        </ul>
-    {% endif %}
+    <a href="{% url 'user_create' %}">Novo Usuário</a>
+    <ul>
+        {% for u in usuarios %}
+            <li>{{ u.usuario.username }} - {{ u.get_perfil_display }}</li>
+        {% empty %}
+            <li>Nenhum usuário cadastrado.</li>
+        {% endfor %}
+    </ul>
 </body>
 </html>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -29,7 +29,7 @@ def custom_login(request):
 def user_list(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
     if perfil != "admin":
-        return render(request, "accounts/user_list.html", {"sem_permissao": True})
+        return render(request, "sem_permissao.html")
     usuarios = Cliente.objects.filter(criado_por=request.user)
     return render(request, "accounts/user_list.html", {"usuarios": usuarios})
 
@@ -38,7 +38,7 @@ def user_list(request):
 def user_create(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
     if perfil != "admin":
-        return render(request, "accounts/user_form.html", {"sem_permissao": True})
+        return render(request, "sem_permissao.html")
     if request.method == "POST":
         form = UsuarioForm(request.POST)
         if form.is_valid():

--- a/gestao/forms.py
+++ b/gestao/forms.py
@@ -41,10 +41,11 @@ class NovoClienteForm(forms.ModelForm):
     first_name = forms.CharField(max_length=150, required=False)
     last_name = forms.CharField(max_length=150, required=False)
     email = forms.EmailField(required=False)
+    perfil = forms.CharField(initial='cliente', widget=forms.HiddenInput())
 
     class Meta:
         model = Cliente
-        fields = ['telefone', 'data_nascimento', 'cpf', 'perfil', 'observacoes', 'ativo']
+        fields = ['telefone', 'data_nascimento', 'cpf', 'observacoes', 'ativo', 'perfil']
 
 
 class AeroportoForm(forms.ModelForm):

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -23,6 +23,7 @@
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_calculadora %}{% endblock %}" href="{% url 'admin_calculadora_cotacao' %}">Calculadora</a>
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_auditoria %}{% endblock %}" href="{% url 'admin_auditoria' %}">Auditoria</a>
+            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700" href="{% url 'user_list' %}">Gerenciar Usuários</a>
             <details class="pt-4 group" {% block dados_complementares_open %}{% endblock %}>
                 <summary class="px-3 py-2 rounded text-blue-400 cursor-pointer hover:bg-zinc-700 focus:outline-none">Dados Complementares</summary>
                 <div class="mt-2 ml-4 flex flex-col space-y-2">

--- a/gestao/templates/admin_custom/form_cliente.html
+++ b/gestao/templates/admin_custom/form_cliente.html
@@ -13,6 +13,7 @@
 <div class="form-wrapper">
 <form method="post">
     {% csrf_token %}
+    {{ form.perfil }}
     <div class="form-title">Cadastro de Cliente</div>
     {% if form.username %}
     <div class="section-title">Credenciais</div>
@@ -61,10 +62,6 @@
         </div>
     </div>
     <div class="form-group">
-        <div style="flex: 1;">
-            <label class="form-label" for="{{ form.perfil.id_for_label }}">Perfil</label>
-            {{ form.perfil }}
-        </div>
         <div style="flex: 1;">
             <label class="form-label" for="{{ form.ativo.id_for_label }}">Ativo</label>
             {{ form.ativo }}

--- a/gestao/templates/sem_permissao.html
+++ b/gestao/templates/sem_permissao.html
@@ -1,0 +1,6 @@
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Sem Permissão{% endblock %}
+{% block header_title %}Sem Permissão{% endblock %}
+{% block content %}
+<div class="alert alert-warning text-center">Você não tem permissão para acessar esta funcionalidade.</div>
+{% endblock %}

--- a/gestao/views/auditoria.py
+++ b/gestao/views/auditoria.py
@@ -1,11 +1,11 @@
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
-
-from .utils import admin_required
 from ..models import AuditLog
 
 @login_required
-@user_passes_test(admin_required)
 def admin_auditoria(request):
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     logs = AuditLog.objects.select_related('user').all()
     return render(request, 'admin_custom/auditoria.html', {'logs': logs})


### PR DESCRIPTION
## Summary
- Expose "Gerenciar Usuários" in sidebar for all roles
- Add central `sem_permissao` page and enforce admin checks in protected views
- Fix client creation to force hidden `perfil`='cliente'

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688eb8e7f8b483279ad47bdc87d287ea