### PR TITLE
feat: update access control and user forms

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -15,8 +15,8 @@
     {% endif %}
     <form method="POST">
         {% csrf_token %}
-        <label>Usuário:</label>
-        <input type="text" name="username" required><br>
+        <label>CPF:</label>
+        <input type="text" name="cpf" required><br>
         <label>Senha:</label>
         <input type="password" name="password" required><br>
         <label>Tipo de acesso:</label>

--- a/accounts/templates/accounts/user_form.html
+++ b/accounts/templates/accounts/user_form.html
@@ -1,24 +1,32 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Novo Usuário</title>
-</head>
-<body>
-    <h2>Criar Usuário</h2>
-    {% if messages %}
-      <ul>
-        {% for message in messages %}
-          <li style="color:green">{{ message }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-    {% if form %}
-    <form method="POST">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Salvar</button>
-    </form>
-    {% endif %}
-</body>
-</html>
+{% extends "admin_custom/base_admin.html" %}
+{% load static %}
+{% block title %}Novo Usuário{% endblock %}
+{% block header_title %}Gerenciar Usuários{% endblock %}
+{% block extra_head %}<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">{% endblock %}
+{% block content %}
+<div class="form-wrapper">
+  <form method="POST">
+    {% csrf_token %}
+    <div class="form-title">Novo Usuário</div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.nome_completo.id_for_label }}">{{ form.nome_completo.label }}</label>
+      {{ form.nome_completo }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.cpf.id_for_label }}">{{ form.cpf.label }}</label>
+      {{ form.cpf }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.perfil.id_for_label }}">{{ form.perfil.label }}</label>
+      {{ form.perfil }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
+      {{ form.password }}
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Salvar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/user_list.html
+++ b/accounts/templates/accounts/user_list.html
@@ -1,18 +1,13 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Usuários</title>
-</head>
-<body>
-    <h2>Usuários</h2>
-    <a href="{% url 'user_create' %}">Novo Usuário</a>
-    <ul>
-        {% for u in usuarios %}
-            <li>{{ u.usuario.username }} - {{ u.get_perfil_display }}</li>
-        {% empty %}
-            <li>Nenhum usuário cadastrado.</li>
-        {% endfor %}
-    </ul>
-</body>
-</html>
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Usuários{% endblock %}
+{% block header_title %}Gerenciar Usuários{% endblock %}
+{% block content %}
+<a href="{% url 'user_create' %}" class="btn-primary inline-block mb-4">Novo Usuário</a>
+<ul class="space-y-2">
+  {% for u in usuarios %}
+    <li>{{ u.usuario.first_name }} - {{ u.get_perfil_display }}</li>
+  {% empty %}
+    <li>Nenhum usuário cadastrado.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -7,11 +7,18 @@ from .forms import UsuarioForm, ClientePublicoForm
 
 def custom_login(request):
     if request.method == "POST":
-        username = request.POST.get("username")
+        cpf = request.POST.get("cpf")
         password = request.POST.get("password")
         perfil = request.POST.get("perfil")
 
-        user = authenticate(request, username=username, password=password)
+        user = None
+        try:
+            cliente = Cliente.objects.get(cpf=cpf)
+            user = authenticate(
+                request, username=cliente.usuario.username, password=password
+            )
+        except Cliente.DoesNotExist:
+            user = None
         if user:
             login(request, user)
             if perfil in ["admin", "operador"] and user.is_staff:
@@ -21,7 +28,7 @@ def custom_login(request):
             else:
                 messages.error(request, "Tipo de usuário inválido para esse acesso.")
         else:
-            messages.error(request, "Usuário ou senha inválidos.")
+            messages.error(request, "CPF ou senha inválidos.")
     return render(request, "accounts/login.html")
 
 

--- a/gestao/templates/sem_permissao.html
+++ b/gestao/templates/sem_permissao.html
@@ -2,5 +2,5 @@
 {% block title %}Sem Permissão{% endblock %}
 {% block header_title %}Sem Permissão{% endblock %}
 {% block content %}
-<div class="alert alert-warning text-center">Você não tem permissão para acessar esta funcionalidade.</div>
+<div class="alert alert-warning text-center">Ação não autorizada.</div>
 {% endblock %}

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -43,7 +43,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 

--- a/gestao/views/companhias.py
+++ b/gestao/views/companhias.py
@@ -36,7 +36,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -90,6 +90,9 @@ def editar_companhia(request, companhia_id):
 def deletar_companhia(request, companhia_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     CompanhiaAerea.objects.filter(id=companhia_id).delete()
     messages.success(request, "Companhia aérea deletada com sucesso.")
     return redirect("admin_companhias")

--- a/gestao/views/cotacoes.py
+++ b/gestao/views/cotacoes.py
@@ -45,7 +45,7 @@ from decimal import Decimal
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -82,6 +82,9 @@ def admin_cotacoes(request):
 def deletar_cotacao(request, cotacao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ValorMilheiro.objects.filter(id=cotacao_id).delete()
     messages.success(request, "Cotação deletada com sucesso.")
     return redirect("admin_cotacoes")
@@ -186,6 +189,9 @@ def editar_cotacao_voo(request, cotacao_id):
 def deletar_cotacao_voo(request, cotacao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     CotacaoVoo.objects.filter(id=cotacao_id).delete()
     messages.success(request, "Cotação de voo deletada com sucesso.")
     return redirect("admin_cotacoes_voo")

--- a/gestao/views/emissoes.py
+++ b/gestao/views/emissoes.py
@@ -42,7 +42,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -273,6 +273,9 @@ def emissao_pdf(request, emissao_id):
 def deletar_emissao(request, emissao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     EmissaoPassagem.objects.filter(id=emissao_id).delete()
     messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_emissoes")
@@ -334,6 +337,9 @@ def editar_emissao_hotel(request, emissao_id):
 def deletar_emissao_hotel(request, emissao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     EmissaoHotel.objects.filter(id=emissao_id).delete()
     messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_hoteis")

--- a/gestao/views/programas.py
+++ b/gestao/views/programas.py
@@ -36,7 +36,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -90,6 +90,9 @@ def editar_programa(request, programa_id):
 def deletar_programa(request, programa_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ProgramaFidelidade.objects.filter(id=programa_id).delete()
     messages.success(request, "Programa deletado com sucesso.")
     return redirect("admin_programas")

--- a/gestao/views/utils.py
+++ b/gestao/views/utils.py
@@ -46,7 +46,7 @@ def verificar_admin(request):
     if request.user.is_superuser:
         return None
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -93,6 +93,9 @@ def editar_conta(request, conta_id):
 def deletar_conta(request, conta_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ContaFidelidade.objects.filter(id=conta_id).delete()
     messages.success(request, "Conta deletada com sucesso.")
     return redirect("admin_contas")
@@ -159,6 +162,9 @@ def criar_aeroporto(request):
 def deletar_aeroporto(request, aeroporto_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     Aeroporto.objects.filter(id=aeroporto_id).delete()
     messages.success(request, "Aeroporto deletado com sucesso.")
     return redirect("admin_aeroportos")

--- a/painel_cliente/templates/registration/login.html
+++ b/painel_cliente/templates/registration/login.html
@@ -101,8 +101,8 @@
 
     <form method="post">
       {% csrf_token %}
-      <label for="id_username">{{ form.username.label }}</label>
-      {{ form.username }}
+      <label for="id_cpf">{{ form.cpf.label }}</label>
+      {{ form.cpf }}
 
       <label for="id_password">{{ form.password.label }}</label>
       {{ form.password }}


### PR DESCRIPTION
## Summary
- allow login with CPF for admins, operators and super admins
- redesign user management pages using base admin layout
- restrict destructive actions to administrators only

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688ed76725748327b47d97cef96e6c8e