### PR TITLE
feat: update access control and user forms

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AccountsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'accounts'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.signals import user_logged_in
+from django.contrib.sessions.models import Session
+from django.dispatch import receiver
+from django.utils import timezone
+
+@receiver(user_logged_in)
+def enforce_single_session(sender, request, user, **kwargs):
+    sessions = Session.objects.filter(expire_date__gte=timezone.now())
+    for session in sessions:
+        data = session.get_decoded()
+        if data.get('_auth_user_id') == str(user.id) and session.session_key != request.session.session_key:
+            session.delete()

--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -15,8 +15,8 @@
     {% endif %}
     <form method="POST">
         {% csrf_token %}
-        <label>Usuário:</label>
-        <input type="text" name="username" required><br>
+        <label>Usuário/CPF:</label>
+        <input type="text" name="identifier" required><br>
         <label>Senha:</label>
         <input type="password" name="password" required><br>
         <label>Tipo de acesso:</label>
@@ -24,6 +24,7 @@
             <option value="cliente">Cliente</option>
             <option value="operador">Operador</option>
             <option value="admin">Administrador</option>
+            <option value="superadmin">Super Admin</option>
         </select><br><br>
         <button type="submit">Entrar</button>
     </form>

--- a/accounts/templates/accounts/user_form.html
+++ b/accounts/templates/accounts/user_form.html
@@ -1,24 +1,32 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Novo Usuário</title>
-</head>
-<body>
-    <h2>Criar Usuário</h2>
-    {% if messages %}
-      <ul>
-        {% for message in messages %}
-          <li style="color:green">{{ message }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-    {% if form %}
-    <form method="POST">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Salvar</button>
-    </form>
-    {% endif %}
-</body>
-</html>
+{% extends "admin_custom/base_admin.html" %}
+{% load static %}
+{% block title %}Novo Usuário{% endblock %}
+{% block header_title %}Usuários da Empresa{% endblock %}
+{% block extra_head %}<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">{% endblock %}
+{% block content %}
+<div class="form-wrapper">
+  <form method="POST">
+    {% csrf_token %}
+    <div class="form-title">Novo Usuário</div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.nome_completo.id_for_label }}">{{ form.nome_completo.label }}</label>
+      {{ form.nome_completo }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.cpf.id_for_label }}">{{ form.cpf.label }}</label>
+      {{ form.cpf }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.perfil.id_for_label }}">{{ form.perfil.label }}</label>
+      {{ form.perfil }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
+      {{ form.password }}
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Salvar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/user_list.html
+++ b/accounts/templates/accounts/user_list.html
@@ -1,18 +1,13 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Usuários</title>
-</head>
-<body>
-    <h2>Usuários</h2>
-    <a href="{% url 'user_create' %}">Novo Usuário</a>
-    <ul>
-        {% for u in usuarios %}
-            <li>{{ u.usuario.username }} - {{ u.get_perfil_display }}</li>
-        {% empty %}
-            <li>Nenhum usuário cadastrado.</li>
-        {% endfor %}
-    </ul>
-</body>
-</html>
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Usuários da Empresa{% endblock %}
+{% block header_title %}Usuários da Empresa{% endblock %}
+{% block content %}
+<a href="{% url 'user_create' %}" class="btn-primary inline-block mb-4">Novo Usuário</a>
+<ul class="space-y-2">
+  {% for u in usuarios %}
+    <li>{{ u.usuario.first_name }} - {{ u.get_perfil_display }}</li>
+  {% empty %}
+    <li>Nenhum usuário cadastrado.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,51 +2,78 @@ from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 from django.contrib import messages
+from django.utils.text import slugify
 from gestao.models import Cliente
 from .forms import UsuarioForm, ClientePublicoForm
 
 def custom_login(request):
     if request.method == "POST":
-        username = request.POST.get("username")
+        identifier = request.POST.get("identifier")
         password = request.POST.get("password")
         perfil = request.POST.get("perfil")
+
+        username = None
+        if perfil == "cliente":
+            try:
+                cliente = Cliente.objects.get(cpf=identifier)
+                username = cliente.usuario.username
+            except Cliente.DoesNotExist:
+                username = None
+        elif perfil == "superadmin":
+            username = slugify(identifier)
+        else:
+            username = identifier
 
         user = authenticate(request, username=username, password=password)
         if user:
             login(request, user)
-            if perfil in ["admin", "operador"] and user.is_staff:
+            user_perfil = getattr(getattr(user, "cliente_gestao", None), "perfil", "")
+            if perfil == "superadmin" and user.is_superuser:
+                return redirect('/admin/')
+            elif perfil == "admin" and user_perfil == "admin":
+                return redirect('/admin/')
+            elif perfil == "operador" and user_perfil == "operador":
                 return redirect('/admin/')
             elif perfil == "cliente" and not user.is_staff:
                 return redirect('/painel/')
             else:
                 messages.error(request, "Tipo de usuário inválido para esse acesso.")
         else:
-            messages.error(request, "Usuário ou senha inválidos.")
+            messages.error(request, "Usuário/CPF ou senha inválidos.")
     return render(request, "accounts/login.html")
 
 
 @login_required
 def user_list(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if not request.user.is_superuser and perfil != "admin":
+    if request.user.is_superuser:
+        usuarios = Cliente.objects.filter(criado_por=request.user, perfil="admin")
+    elif perfil == "admin":
+        usuarios = Cliente.objects.filter(criado_por=request.user)
+    else:
         return render(request, "sem_permissao.html")
-    usuarios = Cliente.objects.filter(criado_por=request.user)
     return render(request, "accounts/user_list.html", {"usuarios": usuarios})
 
 
 @login_required
 def user_create(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if not request.user.is_superuser and perfil != "admin":
+    if request.user.is_superuser:
+        allowed = [("admin", "Administrador")]
+    elif perfil == "admin":
+        allowed = [("operador", "Operador")]
+    else:
         return render(request, "sem_permissao.html")
     if request.method == "POST":
         form = UsuarioForm(request.POST)
+        form.fields['perfil'].choices = allowed
         if form.is_valid():
             form.save(criado_por=request.user)
             messages.success(request, "Usuário criado com sucesso.")
             return redirect("user_list")
     else:
         form = UsuarioForm()
+        form.fields['perfil'].choices = allowed
     return render(request, "accounts/user_form.html", {"form": form})
 
 

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -15,23 +15,28 @@
             <span class="text-amber-300">Gestão</span> Admin
         </div>
         <nav class="flex flex-col space-y-2">
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_dashboard %}{% endblock %}" href="{% url 'admin_dashboard' %}">Dashboard</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_clientes %}{% endblock %}" href="{% url 'admin_clientes' %}">Clientes</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_contas %}{% endblock %}" href="{% url 'admin_contas' %}">Contas Fidelidade</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_cotacoes_voo %}{% endblock %}" href="{% url 'admin_cotacoes_voo' %}">Cotações</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_emissoes %}{% endblock %}" href="{% url 'admin_emissoes' %}">Emissões</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_calculadora %}{% endblock %}" href="{% url 'admin_calculadora_cotacao' %}">Calculadora</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_auditoria %}{% endblock %}" href="{% url 'admin_auditoria' %}">Auditoria</a>
-            <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700" href="{% url 'user_list' %}">Gerenciar Usuários</a>
-            <details class="pt-4 group" {% block dados_complementares_open %}{% endblock %}>
-                <summary class="px-3 py-2 rounded text-blue-400 cursor-pointer hover:bg-zinc-700 focus:outline-none">Dados Complementares</summary>
-                <div class="mt-2 ml-4 flex flex-col space-y-2">
-                    <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_aeroportos %}{% endblock %}" href="{% url 'admin_aeroportos' %}">Aeroporto</a>
-                    <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_companhias %}{% endblock %}" href="{% url 'admin_companhias' %}">Companhia Aérea</a>
-                    <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_programas %}{% endblock %}" href="{% url 'admin_programas' %}">Programa de Pontos</a>
-                </div>
-            </details>
+            {% if not request.user.is_superuser %}
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_dashboard %}{% endblock %}" href="{% url 'admin_dashboard' %}">Dashboard</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_clientes %}{% endblock %}" href="{% url 'admin_clientes' %}">Clientes</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_contas %}{% endblock %}" href="{% url 'admin_contas' %}">Contas Fidelidade</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_cotacoes_voo %}{% endblock %}" href="{% url 'admin_cotacoes_voo' %}">Cotações</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_emissoes %}{% endblock %}" href="{% url 'admin_emissoes' %}">Emissões</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">Hotéis</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_calculadora %}{% endblock %}" href="{% url 'admin_calculadora_cotacao' %}">Calculadora</a>
+                <details class="pt-4 group" {% block dados_complementares_open %}{% endblock %}>
+                    <summary class="px-3 py-2 rounded text-blue-400 cursor-pointer hover:bg-zinc-700 focus:outline-none">Dados Complementares</summary>
+                    <div class="mt-2 ml-4 flex flex-col space-y-2">
+                        <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_aeroportos %}{% endblock %}" href="{% url 'admin_aeroportos' %}">Aeroporto</a>
+                        <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_companhias %}{% endblock %}" href="{% url 'admin_companhias' %}">Companhia Aérea</a>
+                        <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_programas %}{% endblock %}" href="{% url 'admin_programas' %}">Programa de Pontos</a>
+                    </div>
+                </details>
+            {% endif %}
+            <div class="pt-4">
+                <p class="px-3 text-zinc-400 uppercase text-xs mb-2">Administrativo</p>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700 {% block menu_auditoria %}{% endblock %}" href="{% url 'admin_auditoria' %}">Auditoria</a>
+                <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700" href="{% url 'user_list' %}">Usuários da Empresa</a>
+            </div>
             <a class="block px-3 py-2 rounded text-blue-400 hover:bg-zinc-700" href="{% url 'logout' %}">Sair</a>
         </nav>
     </aside>

--- a/gestao/templates/sem_permissao.html
+++ b/gestao/templates/sem_permissao.html
@@ -2,5 +2,5 @@
 {% block title %}Sem Permissão{% endblock %}
 {% block header_title %}Sem Permissão{% endblock %}
 {% block content %}
-<div class="alert alert-warning text-center">Você não tem permissão para acessar esta funcionalidade.</div>
+<div class="alert alert-warning text-center">Você não tem permissão para acessar essa funcionalidade.</div>
 {% endblock %}

--- a/gestao/views/auditoria.py
+++ b/gestao/views/auditoria.py
@@ -5,7 +5,7 @@ from ..models import AuditLog
 @login_required
 def admin_auditoria(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil != "admin" and not request.user.is_superuser:
         return render(request, "sem_permissao.html")
     logs = AuditLog.objects.select_related('user').all()
     return render(request, 'admin_custom/auditoria.html', {'logs': logs})

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -43,7 +43,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 

--- a/gestao/views/companhias.py
+++ b/gestao/views/companhias.py
@@ -36,7 +36,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -90,6 +90,9 @@ def editar_companhia(request, companhia_id):
 def deletar_companhia(request, companhia_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     CompanhiaAerea.objects.filter(id=companhia_id).delete()
     messages.success(request, "Companhia aérea deletada com sucesso.")
     return redirect("admin_companhias")

--- a/gestao/views/cotacoes.py
+++ b/gestao/views/cotacoes.py
@@ -45,7 +45,7 @@ from decimal import Decimal
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -82,6 +82,9 @@ def admin_cotacoes(request):
 def deletar_cotacao(request, cotacao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ValorMilheiro.objects.filter(id=cotacao_id).delete()
     messages.success(request, "Cotação deletada com sucesso.")
     return redirect("admin_cotacoes")
@@ -186,6 +189,9 @@ def editar_cotacao_voo(request, cotacao_id):
 def deletar_cotacao_voo(request, cotacao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     CotacaoVoo.objects.filter(id=cotacao_id).delete()
     messages.success(request, "Cotação de voo deletada com sucesso.")
     return redirect("admin_cotacoes_voo")

--- a/gestao/views/emissoes.py
+++ b/gestao/views/emissoes.py
@@ -42,7 +42,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -273,6 +273,9 @@ def emissao_pdf(request, emissao_id):
 def deletar_emissao(request, emissao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     EmissaoPassagem.objects.filter(id=emissao_id).delete()
     messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_emissoes")
@@ -334,6 +337,9 @@ def editar_emissao_hotel(request, emissao_id):
 def deletar_emissao_hotel(request, emissao_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     EmissaoHotel.objects.filter(id=emissao_id).delete()
     messages.success(request, "Emissão deletada com sucesso.")
     return redirect("admin_hoteis")

--- a/gestao/views/programas.py
+++ b/gestao/views/programas.py
@@ -36,7 +36,7 @@ from datetime import timedelta
 
 def verificar_admin(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -90,6 +90,9 @@ def editar_programa(request, programa_id):
 def deletar_programa(request, programa_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ProgramaFidelidade.objects.filter(id=programa_id).delete()
     messages.success(request, "Programa deletado com sucesso.")
     return redirect("admin_programas")

--- a/gestao/views/utils.py
+++ b/gestao/views/utils.py
@@ -46,7 +46,7 @@ def verificar_admin(request):
     if request.user.is_superuser:
         return None
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
-    if perfil != "admin":
+    if perfil not in ["admin", "operador"]:
         return render(request, "sem_permissao.html")
     return None
 
@@ -93,6 +93,9 @@ def editar_conta(request, conta_id):
 def deletar_conta(request, conta_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     ContaFidelidade.objects.filter(id=conta_id).delete()
     messages.success(request, "Conta deletada com sucesso.")
     return redirect("admin_contas")
@@ -159,6 +162,9 @@ def criar_aeroporto(request):
 def deletar_aeroporto(request, aeroporto_id):
     if (resp := verificar_admin(request)):
         return resp
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    if perfil != "admin":
+        return render(request, "sem_permissao.html")
     Aeroporto.objects.filter(id=aeroporto_id).delete()
     messages.success(request, "Aeroporto deletado com sucesso.")
     return redirect("admin_aeroportos")

--- a/painel_cliente/templates/registration/login.html
+++ b/painel_cliente/templates/registration/login.html
@@ -101,8 +101,8 @@
 
     <form method="post">
       {% csrf_token %}
-      <label for="id_username">{{ form.username.label }}</label>
-      {{ form.username }}
+      <label for="id_identifier">{{ form.identifier.label }}</label>
+      {{ form.identifier }}
 
       <label for="id_password">{{ form.password.label }}</label>
       {{ form.password }}
@@ -110,8 +110,9 @@
       <label for="tipo_acesso">Tipo de Acesso</label>
       <select name="tipo_acesso" id="tipo_acesso">
         <option value="cliente">Cliente</option>
-        <option value="admin">Administrador</option>
         <option value="operador">Operador</option>
+        <option value="admin">Administrador</option>
+        <option value="superadmin">Super Admin</option>
       </select>
 
       <input type="submit" value="Entrar">


### PR DESCRIPTION
## Summary
- require CPF for super admin login while admins and operators use username credentials
- add "Administrativo" sidebar grouping audit and company user management and limit super admin menus
- show unified permission warning and enforce single active session per account

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688ed76725748327b47d97cef96e6c8e