### PR TITLE
Simplify admin and user management

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.auth.models import User
 from django.utils.text import slugify
-from gestao.models import Cliente
+from gestao.models import Cliente, Empresa, Administrador, Operador
 
 
 class LoginForm(forms.Form):
@@ -13,8 +13,28 @@ class LoginForm(forms.Form):
 class UsuarioForm(forms.Form):
     nome_completo = forms.CharField(max_length=150)
     cpf = forms.CharField(max_length=14)
-    perfil = forms.ChoiceField(choices=[("admin", "Administrador"), ("operador", "Operador"), ("cliente", "cliente")])
+    perfil = forms.ChoiceField(choices=[("admin", "Administrador"), ("operador", "Operador")])
     password = forms.CharField(widget=forms.PasswordInput)
+    acesso_ate = forms.DateField(required=False, widget=forms.DateInput(attrs={'type': 'date'}))
+    empresa = forms.ModelChoiceField(queryset=Empresa.objects.all(), required=False)
+    nova_empresa_nome = forms.CharField(required=False, label="Nova empresa")
+    limite_operadores = forms.IntegerField(required=False, label="Limite de operadores")
+    limite_clientes = forms.IntegerField(required=False, label="Limite de clientes")
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        super().__init__(*args, **kwargs)
+        if self.user and not self.user.is_superuser:
+            admin = Administrador.objects.filter(usuario=self.user).first()
+            if admin:
+                self.fields['empresa'].queryset = Empresa.objects.filter(id=admin.empresa_id)
+                self.fields['empresa'].initial = admin.empresa
+                self.fields['empresa'].disabled = True
+                self.fields['nova_empresa_nome'].widget = forms.HiddenInput()
+                self.fields['limite_operadores'].widget = forms.HiddenInput()
+                self.fields['limite_clientes'].widget = forms.HiddenInput()
+        else:
+            self.fields['empresa'].queryset = Empresa.objects.all()
 
     def save(self, criado_por=None):
         nome = self.cleaned_data["nome_completo"]
@@ -25,14 +45,36 @@ class UsuarioForm(forms.Form):
             password=self.cleaned_data["password"],
             first_name=nome,
         )
-        user.is_staff = True
+        perfil = self.cleaned_data["perfil"]
+        user.is_staff = perfil in ["admin", "operador"]
         user.save()
         Cliente.objects.create(
             usuario=user,
             cpf=cpf,
-            perfil=self.cleaned_data["perfil"],
+            perfil=perfil,
             criado_por=criado_por,
         )
+        if perfil == "admin":
+            empresa = self.cleaned_data.get("empresa")
+            if not empresa:
+                empresa = Empresa.objects.create(
+                    nome=self.cleaned_data.get("nova_empresa_nome") or nome,
+                    limite_operadores=self.cleaned_data.get("limite_operadores"),
+                    limite_clientes=self.cleaned_data.get("limite_clientes"),
+                )
+            Administrador.objects.create(
+                usuario=user,
+                empresa=empresa,
+                acesso_ate=self.cleaned_data.get("acesso_ate"),
+            )
+        elif perfil == "operador":
+            admin = Administrador.objects.filter(usuario=criado_por).first()
+            empresa = admin.empresa if admin else None
+            Operador.objects.create(
+                usuario=user,
+                admin=admin,
+                empresa=empresa,
+            )
         return user
 
 class ClientePublicoForm(forms.ModelForm):

--- a/accounts/templates/accounts/user_form.html
+++ b/accounts/templates/accounts/user_form.html
@@ -24,6 +24,26 @@
       <label class="form-label" for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
       {{ form.password }}
     </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.acesso_ate.id_for_label }}">{{ form.acesso_ate.label }}</label>
+      {{ form.acesso_ate }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.empresa.id_for_label }}">{{ form.empresa.label }}</label>
+      {{ form.empresa }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.nova_empresa_nome.id_for_label }}">{{ form.nova_empresa_nome.label }}</label>
+      {{ form.nova_empresa_nome }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.limite_operadores.id_for_label }}">{{ form.limite_operadores.label }}</label>
+      {{ form.limite_operadores }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.limite_clientes.id_for_label }}">{{ form.limite_clientes.label }}</label>
+      {{ form.limite_clientes }}
+    </div>
     <div class="form-actions">
       <button type="submit" class="btn-primary">Salvar</button>
     </div>

--- a/gestao/admin.py
+++ b/gestao/admin.py
@@ -1,10 +1,5 @@
 from django.contrib import admin
-from .models import (
-    Cliente, ProgramaFidelidade,
-    ContaFidelidade, EmissaoPassagem,
-    EmissaoHotel, ValorMilheiro,
-    Empresa, Administrador, Operador, ClienteEmpresa,
-)
+from .models import Cliente, Empresa, Administrador, Operador, ClienteEmpresa
 
 
 @admin.register(Empresa)
@@ -24,6 +19,15 @@ class AdministradorAdmin(admin.ModelAdmin):
         'usuario__username', 'usuario__first_name', 'usuario__last_name'
     )
 
+    def save_model(self, request, obj, form, change):
+        obj.usuario.is_staff = True
+        obj.usuario.save()
+        super().save_model(request, obj, form, change)
+        Cliente.objects.get_or_create(
+            usuario=obj.usuario,
+            defaults={'perfil': 'admin'}
+        )
+
 
 @admin.register(Operador)
 class OperadorAdmin(admin.ModelAdmin):
@@ -32,6 +36,15 @@ class OperadorAdmin(admin.ModelAdmin):
     search_fields = (
         'usuario__username', 'usuario__first_name', 'usuario__last_name'
     )
+
+    def save_model(self, request, obj, form, change):
+        obj.usuario.is_staff = True
+        obj.usuario.save()
+        super().save_model(request, obj, form, change)
+        Cliente.objects.get_or_create(
+            usuario=obj.usuario,
+            defaults={'perfil': 'operador'}
+        )
 
 
 @admin.register(ClienteEmpresa)
@@ -42,96 +55,11 @@ class ClienteEmpresaAdmin(admin.ModelAdmin):
         'usuario__username', 'usuario__first_name', 'usuario__last_name'
     )
 
-admin.site.register(Cliente)
-admin.site.register(ProgramaFidelidade)
-
-class ContaFidelidadeAdmin(admin.ModelAdmin):
-    list_display = (
-        'cliente',
-        'programa',
-        'get_saldo_pontos',
-        'get_valor_total_pago',
-        'get_valor_medio',
-        'data_inicio_clube',  
-        'clube_periodicidade',
-        'pontos_clube_mes',
-        'valor_assinatura_clube',
-    )
-
-    fields = (
-        'cliente',
-        'programa',
-        'clube_periodicidade',
-        'pontos_clube_mes',
-        'valor_assinatura_clube',
-        'data_inicio_clube',
-        'validade',
-        'get_saldo_pontos',
-        'get_valor_total_pago',
-        'get_valor_medio',
-    )
-
-    readonly_fields = (
-        'get_saldo_pontos',
-        'get_valor_total_pago',
-        'get_valor_medio',
-    )
-
-    def get_saldo_pontos(self, obj):
-        return obj.saldo_pontos
-    get_saldo_pontos.short_description = 'Saldo pontos'
-
-    def get_valor_total_pago(self, obj):
-        return f'{obj.valor_total_pago:.2f}'
-    get_valor_total_pago.short_description = 'Valor total pago'
-
-    def get_valor_medio(self, obj):
-        saldo = obj.saldo_pontos
-        if saldo > 0:
-            valor_medio = obj.valor_total_pago / (saldo / 1000)
-        else:
-            valor_medio = 0
-        return f'{valor_medio:.2f}'
-    get_valor_medio.short_description = 'Valor médio (por 1.000 pontos)'
-
-   
-admin.site.register(ContaFidelidade, ContaFidelidadeAdmin)
-
-class EmissaoPassagemAdmin(admin.ModelAdmin):
-    list_display = (
-        'cliente',
-        'programa',
-        'aeroporto_partida',
-        'aeroporto_destino',
-        'data_ida',
-        'data_volta',
-        'qtd_passageiros',
-        'valor_referencia',
-        'valor_pago',
-        'pontos_utilizados',
-        'valor_referencia_pontos',
-        'economia_obtida',
-        'companhia_aerea',
-        'localizador',
-    )
-
-admin.site.register(EmissaoPassagem, EmissaoPassagemAdmin)
-
-
-class EmissaoHotelAdmin(admin.ModelAdmin):
-    list_display = (
-        'cliente',
-        'nome_hotel',
-        'check_in',
-        'check_out',
-        'valor_referencia',
-        'valor_pago',
-        'economia_obtida',
-    )
-
-admin.site.register(EmissaoHotel, EmissaoHotelAdmin)
-
-@admin.register(ValorMilheiro)
-class ValorMilheiroAdmin(admin.ModelAdmin):
-    list_display = ('programa_nome', 'valor_mercado', 'atualizado_em')
-    search_fields = ('programa_nome',)
+    def save_model(self, request, obj, form, change):
+        obj.usuario.is_staff = False
+        obj.usuario.save()
+        super().save_model(request, obj, form, change)
+        Cliente.objects.get_or_create(
+            usuario=obj.usuario,
+            defaults={'perfil': 'cliente'}
+        )


### PR DESCRIPTION
## Summary
- Trim Django admin to company and user management with automatic profile setup
- Add company, expiry and role options to user creation form and view
- Enforce admin access expiry cascading to operators and clients

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f742efec88327b3058a03fa710194