### PR TITLE
Restrict admin actions to company scope

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -9,7 +9,7 @@ class UsuarioForm(forms.Form):
     perfil = forms.ChoiceField(choices=[("admin", "Administrador"), ("operador", "Operador"), ("cliente", "cliente")])
     password = forms.CharField(widget=forms.PasswordInput)
 
-    def save(self, criado_por=None):
+    def save(self, criado_por=None, empresa=None):
         nome = self.cleaned_data["nome_completo"]
         cpf = self.cleaned_data["cpf"]
         username = slugify(cpf) or slugify(nome) or "user"
@@ -25,6 +25,7 @@ class UsuarioForm(forms.Form):
             cpf=cpf,
             perfil=self.cleaned_data["perfil"],
             criado_por=criado_por,
+            empresa=empresa,
         )
         return user
 

--- a/accounts/templates/accounts/user_list.html
+++ b/accounts/templates/accounts/user_list.html
@@ -5,7 +5,7 @@
 <a href="{% url 'user_create' %}" class="btn-primary inline-block mb-4">Novo Usuário</a>
 <ul class="space-y-2">
   {% for u in usuarios %}
-    <li>{{ u.usuario.first_name }} - {{ u.get_perfil_display }}</li>
+    <li>{{ u.usuario.first_name }} - {{ u.get_perfil_display }} - <a href="{% url 'user_delete' u.id %}" class="text-red-500">Remover</a></li>
   {% empty %}
     <li>Nenhum usuário cadastrado.</li>
   {% endfor %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import custom_login, user_list, user_create, cliente_create
+from .views import custom_login, user_list, user_create, user_delete, cliente_create
 
 urlpatterns = [
     path('login/', custom_login, name='login'),
     path('usuarios/', user_list, name='user_list'),
     path('usuarios/novo/', user_create, name='user_create'),
+    path('usuarios/<int:user_id>/deletar/', user_delete, name='user_delete'),
     path('cliente/novo/', cliente_create, name='cliente_create'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.utils.text import slugify
 from gestao.models import Cliente
@@ -46,10 +46,11 @@ def custom_login(request):
 @login_required
 def user_list(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    empresa = getattr(getattr(request.user, "cliente_gestao", None), "empresa", None)
     if request.user.is_superuser:
         usuarios = Cliente.objects.filter(criado_por=request.user, perfil="admin")
-    elif perfil == "admin":
-        usuarios = Cliente.objects.filter(criado_por=request.user)
+    elif perfil == "admin" and empresa:
+        usuarios = Cliente.objects.filter(empresa=empresa, perfil__in=["admin", "operador"])
     else:
         return render(request, "sem_permissao.html")
     return render(request, "accounts/user_list.html", {"usuarios": usuarios})
@@ -58,9 +59,10 @@ def user_list(request):
 @login_required
 def user_create(request):
     perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    empresa = getattr(getattr(request.user, "cliente_gestao", None), "empresa", None)
     if request.user.is_superuser:
         allowed = [("admin", "Administrador")]
-    elif perfil == "admin":
+    elif perfil == "admin" and empresa:
         allowed = [("operador", "Operador")]
     else:
         return render(request, "sem_permissao.html")
@@ -68,13 +70,36 @@ def user_create(request):
         form = UsuarioForm(request.POST)
         form.fields['perfil'].choices = allowed
         if form.is_valid():
-            form.save(criado_por=request.user)
+            perfil_novo = form.cleaned_data['perfil']
+            if empresa:
+                limites = {
+                    'admin': empresa.limite_administradores,
+                    'operador': empresa.limite_operadores,
+                }
+                total = Cliente.objects.filter(empresa=empresa, perfil=perfil_novo).count()
+                if total >= limites.get(perfil_novo, 0):
+                    messages.error(request, "Limite de usuários atingido.")
+                    return render(request, "accounts/user_form.html", {"form": form})
+            form.save(criado_por=request.user, empresa=empresa)
             messages.success(request, "Usuário criado com sucesso.")
             return redirect("user_list")
     else:
         form = UsuarioForm()
         form.fields['perfil'].choices = allowed
     return render(request, "accounts/user_form.html", {"form": form})
+
+
+@login_required
+def user_delete(request, user_id):
+    perfil = getattr(getattr(request.user, "cliente_gestao", None), "perfil", "")
+    empresa = getattr(getattr(request.user, "cliente_gestao", None), "empresa", None)
+    if perfil != "admin" or not empresa:
+        return render(request, "sem_permissao.html")
+    usuario = get_object_or_404(Cliente, id=user_id, empresa=empresa, perfil__in=["admin", "operador"])
+    usuario.usuario.delete()
+    usuario.delete()
+    messages.success(request, "Usuário removido com sucesso.")
+    return redirect("user_list")
 
 
 def cliente_create(request):


### PR DESCRIPTION
## Summary
- link created users to the admin's company and enforce company limits
- filter user and client management by company and allow deleting users
- restrict client views to company scope with limit checks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688fa5c9d094832780b1557830d9a4f9