### PR TITLE
Add Render configuration for automatic migrations

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: site-fpp
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "gunicorn core.wsgi:application"
+    preDeployCommand: "python manage.py migrate"


### PR DESCRIPTION
## Summary
- configure Render to install dependencies and apply migrations automatically before deployment

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68909e60fb9c8327a361ddcdefb6d1b7