### PR TITLE
Serve static files on Render

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -127,6 +128,7 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 
 # Default primary key field type

--- a/render.yaml
+++ b/render.yaml
@@ -4,5 +4,4 @@ services:
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "gunicorn core.wsgi:application"
-    preDeployCommand: "python manage.py migrate"
-    preDeployCommand: "python manage.py collectstatic --noinput"
+    preDeployCommand: "python manage.py migrate && python manage.py collectstatic --noinput"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==5.2.4
 gunicorn
+whitenoise
 pandas
 reportlab
 psycopg2-binary


### PR DESCRIPTION
## Summary
- add WhiteNoise to handle static files on Render
- configure middleware and staticfiles storage
- run migrations and collectstatic in Render pre-deploy

## Testing
- `pip install -r requirements.txt`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f705e4ac83278fd4d1b42559f383