### PR TITLE
Unify admin identity across responsive layout

### DIFF
--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -3,6 +3,10 @@ body {
   height: 100%;
 }
 
+:root {
+  --sidebar-width: 256px;
+}
+
 body {
   margin: 0;
   min-height: 100%;
@@ -79,12 +83,35 @@ body {
   background: #ffffff;
 }
 
+.sidebar-header {
+  justify-content: flex-end;
+}
+
+.app-identity {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #2d3748;
+}
+
 .app-main {
   flex: 1;
   overflow-y: auto;
   margin-left: 0;
   padding: 24px;
   background: #f8fafc;
+}
+
+.page-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #2d3748;
 }
 
 @media (max-width: 768px) {
@@ -109,6 +136,16 @@ body {
 
   .app-main {
     padding: 24px 16px;
+  }
+}
+
+@media (min-width: 768px) {
+  .app-identity {
+    position: fixed;
+    top: 24px;
+    left: 24px;
+    width: calc(var(--sidebar-width) - 48px);
+    z-index: 60;
   }
 }
 

--- a/gestao/static/gestao/js/sidebar.js
+++ b/gestao/static/gestao/js/sidebar.js
@@ -21,4 +21,13 @@ document.addEventListener("DOMContentLoaded", () => {
   openButton.addEventListener("click", openSidebar);
   closeButton.addEventListener("click", closeSidebar);
   overlay.addEventListener("click", closeSidebar);
+
+  const navLinks = sidebar.querySelectorAll("a.nav-item");
+  navLinks.forEach((link) => {
+    link.addEventListener("click", () => {
+      if (window.innerWidth < 768) {
+        closeSidebar();
+      }
+    });
+  });
 });

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -21,7 +21,6 @@
 
     <aside class="sidebar fpp-sidebar" data-sidebar>
         <div class="sidebar-header">
-            <h1 class="sidebar-title">Gestão Admin</h1>
             <button class="icon-button sidebar-close" type="button" aria-label="Fechar menu" data-sidebar-close>
                 <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M18 6 6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
@@ -192,9 +191,7 @@
                         <path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
                     </svg>
                 </button>
-                <h2 class="app-header__title">
-                    {% block header_title %}Painel Administrativo{% endblock %}
-                </h2>
+                <span class="app-identity">Gestão Admin</span>
             </div>
             <div class="app-header__actions">
                 <span class="user-name">{{ request.user.get_full_name|default:request.user.username }}</span>
@@ -206,7 +203,8 @@
             <div class="fpp-container">
                 <div class="page-shell">
                     <div class="page-header fpp-header">
-                        <div>
+                        <div class="page-header__titles">
+                            <h1 class="page-title">{% block header_title %}Painel Administrativo{% endblock %}</h1>
                             {% block header_subtitle %}{% endblock %}
                         </div>
                         <div class="page-actions fpp-actions">


### PR DESCRIPTION
### Motivation

- Remove the duplicated system identity on mobile by introducing one conceptual identity element that adapts to breakpoints.  
- On desktop keep the persistent sidebar identity and keep the top header focused on actions only.  
- On mobile let the header act as the primary identity while keeping the sidebar title hidden when opened.  

### Description

- Template: updated `gestao/templates/admin_custom/base_admin.html` to remove the `h1.sidebar-title`, add a single `span.app-identity` in the header, and move the `header_title` block into a new `h1.page-title` inside the page header.  
- CSS: added rules in `gestao/static/gestao/css/layout.css` (root `--sidebar-width`, `.app-identity`, `.page-header__titles`, `.page-title`, and a media rule to position the shared identity in the sidebar area on larger screens), and adjusted `.sidebar-header` alignment so the close button remains correct.  
- JavaScript: updated `gestao/static/gestao/js/sidebar.js` to automatically close the sidebar when a navigation link is clicked on small viewports (`window.innerWidth < 768`).  
- No backend or routing logic was changed; the change is presentation-only and driven by CSS + small JS behavior.  

### Testing

- Started the Django development server with `python manage.py runserver` and the server launched successfully.  
- Ran a headless Playwright script against `http://localhost:8000/` to capture a visual screenshot of the admin layout and it completed successfully.  
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503f574e8c8327bb74b7d89ba6e3cd)