### PR TITLE
CPF limit validation, UX improvements and Sidebar/Header unification

### DIFF
--- a/gestao/models/conta_fidelidade.py
+++ b/gestao/models/conta_fidelidade.py
@@ -3,6 +3,7 @@ from django.db import models
 from .cliente import Cliente
 from .programa_fidelidade import ProgramaFidelidade
 from .conta_administrada import ContaAdministrada
+from gestao.utils import normalize_cpf
 
 
 class ContaFidelidade(models.Model):
@@ -129,12 +130,12 @@ class ContaFidelidade(models.Model):
             filtros["emissao__cliente_id"] = self.cliente_id
         if self.conta_administrada_id:
             filtros["emissao__conta_administrada_id"] = self.conta_administrada_id
-        return (
-            Passageiro.objects.filter(**filtros)
-            .values("documento")
-            .distinct()
-            .count()
-        )
+        cpfs = set()
+        for documento in Passageiro.objects.filter(**filtros).values_list("documento", flat=True):
+            normalized = normalize_cpf(documento)
+            if normalized:
+                cpfs.add(normalized)
+        return len(cpfs)
 
     @property
     def cpfs_disponiveis(self):

--- a/gestao/services/cpf_limite.py
+++ b/gestao/services/cpf_limite.py
@@ -1,0 +1,68 @@
+"""Serviços para validação de limite de CPFs por programa."""
+
+from typing import Iterable, Set, Tuple
+
+from django.core.exceptions import ValidationError
+
+from gestao.models import Passageiro
+from gestao.utils import normalize_cpf
+
+
+def _build_existing_cpfs(
+    *,
+    programa_id: int,
+    cliente_id: int | None = None,
+    conta_administrada_id: int | None = None,
+    exclude_emissao_id: int | None = None,
+) -> Set[str]:
+    filtros = {"emissao__programa_id": programa_id}
+    if cliente_id:
+        filtros["emissao__cliente_id"] = cliente_id
+    if conta_administrada_id:
+        filtros["emissao__conta_administrada_id"] = conta_administrada_id
+
+    qs = Passageiro.objects.filter(**filtros)
+    if exclude_emissao_id:
+        qs = qs.exclude(emissao_id=exclude_emissao_id)
+
+    cpfs = set()
+    for documento in qs.values_list("documento", flat=True):
+        normalized = normalize_cpf(documento)
+        if normalized:
+            cpfs.add(normalized)
+    return cpfs
+
+
+def _normalize_documentos(documentos: Iterable[str]) -> Set[str]:
+    cpfs = set()
+    for doc in documentos:
+        normalized = normalize_cpf(doc)
+        if normalized:
+            cpfs.add(normalized)
+    return cpfs
+
+
+def validar_limite_cpfs(conta, documentos: Iterable[str], emissao_id: int | None = None) -> Tuple[int, int | None]:
+    """Valida o consumo de CPFs e retorna (cpfs_novos, cpfs_disponiveis)."""
+
+    limite = conta.quantidade_cpfs_disponiveis
+    if limite is None:
+        return 0, None
+
+    cpfs_existentes = _build_existing_cpfs(
+        programa_id=conta.programa_id,
+        cliente_id=conta.cliente_id,
+        conta_administrada_id=conta.conta_administrada_id,
+        exclude_emissao_id=emissao_id,
+    )
+    cpfs_na_emissao = _normalize_documentos(documentos)
+    cpfs_novos = cpfs_na_emissao - cpfs_existentes
+    cpfs_disponiveis = max(limite - len(cpfs_existentes), 0)
+
+    if len(cpfs_novos) > cpfs_disponiveis:
+        raise ValidationError(
+            f"Limite de CPFs excedido. Esta emissão adiciona {len(cpfs_novos)} CPF(s) novos, "
+            f"mas restam apenas {cpfs_disponiveis} disponível(is) no programa."
+        )
+
+    return len(cpfs_novos), cpfs_disponiveis

--- a/gestao/static/admin_custom.css
+++ b/gestao/static/admin_custom.css
@@ -123,7 +123,13 @@ button:hover {
 /* ===== Overlay (mobile) ===== */
 
 [data-sidebar-overlay] {
-    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease-in-out;
+    z-index: 35;
 }
 
 /* ===== Mobile ===== */
@@ -145,7 +151,8 @@ button:hover {
     }
 
     body.sidebar-open [data-sidebar-overlay] {
-        display: block;
+        opacity: 1;
+        pointer-events: auto;
     }
 
     .content {

--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -74,6 +74,7 @@ body {
 .app-shell__content {
   margin-left: 256px;
   width: calc(100% - 256px);
+  transition: transform 0.3s ease;
 }
 
 .app-header {
@@ -127,6 +128,10 @@ body {
 
   body.sidebar-open .app-shell .sidebar {
     transform: translateX(0);
+  }
+
+  body.sidebar-open .app-shell__content {
+    transform: translateX(var(--sidebar-width));
   }
 
   .app-shell__content {

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -179,7 +179,7 @@
     <div class="app-shell__content">
         <header class="app-header">
             <div class="app-header__left">
-                <button class="icon-button menu-button" type="button" aria-label="Abrir menu" data-sidebar-toggle>
+                <button class="icon-button menu-button" type="button" aria-label="Abrir menu" data-sidebar-open>
                     <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
                     </svg>
@@ -224,8 +224,8 @@
 
 {% block extra_body %}{% endblock %}
 
-<script src="{% static 'gestao/js/admin_layout.js' %}" defer></script>
 <script src="{% static 'gestao/js/forms.js' %}" defer></script>
+<script type="module" src="{% static 'painel_cliente/js/app.js' %}" defer></script>
 
 </body>
 </html>

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -60,6 +60,8 @@
                 <label class="form-label" for="{{ form.programa.id_for_label }}">Programa <span class="required-asterisk">*</span></label>
                 {{ form.programa }}
                 <p id="programa-info" class="helper-text mt-1"></p>
+                <p id="cpf-consumo-info" class="helper-text mt-1"></p>
+                <p id="cpf-limite-error" class="helper-text mt-1 text-red-500"></p>
             </div>
         </div>
     </div>
@@ -260,7 +262,7 @@
 
     <div class="form-actions">
         <a href="{% url 'admin_emissoes' %}" class="btn btn--outline">Cancelar</a>
-        <button class="btn" type="submit">💾 Salvar emissão</button>
+        <button class="btn" type="submit" id="submit-emissao">💾 Salvar emissão</button>
     </div>
 </form>
 </div>
@@ -277,6 +279,8 @@ const passageirosContainer = document.getElementById('passageiros-container');
 const clienteSelect = document.getElementById('id_cliente');
 const programaSelect = document.getElementById('id_programa');
 const programaInfo = document.getElementById('programa-info');
+const cpfConsumoInfo = document.getElementById('cpf-consumo-info');
+const cpfLimiteError = document.getElementById('cpf-limite-error');
 const tipoTitularSelect = document.getElementById('id_tipo_titular');
 const contaAdmSelect = document.getElementById('id_conta_administrada');
 const clienteWrapper = document.getElementById('cliente-wrapper');
@@ -286,6 +290,7 @@ const valorRefPontosField = document.getElementById('id_valor_referencia_pontos'
 const valorReferenciaField = document.getElementById('id_valor_referencia');
 const valorPagoField = document.getElementById('id_valor_pago');
 const economiaField = document.getElementById('id_economia_obtida');
+const submitButton = document.getElementById('submit-emissao');
 const resumoTrechos = document.getElementById('resumo-trechos');
 const resumoDatas = document.getElementById('resumo-datas');
 const resumoPassageiros = document.getElementById('resumo-passageiros');
@@ -337,6 +342,7 @@ function updateProgramaInfo() {
     } else {
         programaInfo.textContent = "";
     }
+    updateCpfLimite();
     recalcValoresFinanceiros();
 }
 
@@ -451,6 +457,7 @@ function renderPassengerForms() {
             if(cat && p.categoria) cat.value = p.categoria;
         }
     });
+    updateCpfLimite();
 }
 
 ['id_qtd_adultos','id_qtd_criancas','id_qtd_bebes'].forEach(id=>{
@@ -458,6 +465,59 @@ function renderPassengerForms() {
     if(el) el.addEventListener('input', renderPassengerForms);
 });
 renderPassengerForms();
+
+function normalizeCpf(value) {
+    return (value || "").replace(/\D/g, "");
+}
+
+function updateCpfLimite() {
+    if (!cpfConsumoInfo) return;
+    const programas = getProgramasDisponiveis();
+    const selected = programas.find(p => String(p.id) === (programaSelect ? programaSelect.value : ""));
+    if (!selected) {
+        cpfConsumoInfo.textContent = "";
+        if (cpfLimiteError) cpfLimiteError.textContent = "";
+        if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.setAttribute("aria-disabled", "false");
+        }
+        return;
+    }
+
+    const documentos = Array.from(
+        passageirosContainer.querySelectorAll('input[name^="passageiro-"][name$="-documento"]')
+    )
+        .map((input) => normalizeCpf(input.value))
+        .filter(Boolean);
+    const cpfsUnicos = new Set(documentos);
+    const cpfsUsados = new Set((selected.cpfs_usados_list || []).map(normalizeCpf));
+    const cpfsNovos = new Set([...cpfsUnicos].filter((cpf) => !cpfsUsados.has(cpf)));
+    const consumo = cpfsNovos.size;
+
+    const ilimitado = selected.cpfs_total === null || selected.cpfs_total === undefined;
+    if (ilimitado) {
+        cpfConsumoInfo.textContent = `CPFs nesta emissão: ${consumo} • Disponíveis: ilimitado`;
+    } else {
+        cpfConsumoInfo.textContent = `CPFs nesta emissão: ${consumo} • Disponíveis: ${selected.cpfs_disponiveis} de ${selected.cpfs_total}`;
+    }
+
+    const excedeu = !ilimitado && consumo > (selected.cpfs_disponiveis || 0);
+    if (cpfLimiteError) {
+        cpfLimiteError.textContent = excedeu
+            ? "Limite de CPFs excedido para este programa. Revise os documentos informados."
+            : "";
+    }
+    if (submitButton) {
+        submitButton.disabled = excedeu;
+        submitButton.setAttribute("aria-disabled", excedeu ? "true" : "false");
+    }
+}
+
+passageirosContainer.addEventListener('input', (event) => {
+    if (event.target && event.target.name && event.target.name.includes('-documento')) {
+        updateCpfLimite();
+    }
+});
 
 function initEscalaSection(tipo, data){
     const checkbox = document.getElementById(`${tipo}-tem-escala`);

--- a/gestao/templates/admin_custom/movimentacoes.html
+++ b/gestao/templates/admin_custom/movimentacoes.html
@@ -32,7 +32,13 @@
                     <td>{{ mov.data|date:"d/m/Y" }}</td>
                     <td>{{ mov.pontos }}</td>
                     <td>R$ {{ mov.valor_pago|floatformat:2 }}</td>
-                    <td>{{ mov.descricao }}</td>
+                    <td>
+                        {% if mov.emissao_id %}
+                            <a href="{% url 'admin_editar_emissao' mov.emissao_id %}" class="underline">{{ mov.descricao }}</a>
+                        {% else %}
+                            {{ mov.descricao }}
+                        {% endif %}
+                    </td>
                 </tr>
                 {% empty %}
                 <tr><td colspan="4" class="text-center text-red-400 py-4">Nenhuma movimentação lançada.</td></tr>

--- a/gestao/templates/admin_custom/programas_da_conta_administrada.html
+++ b/gestao/templates/admin_custom/programas_da_conta_administrada.html
@@ -23,6 +23,9 @@
                     <th>Saldo Pontos</th>
                     <th>Valor Pago</th>
                     <th>Valor Médio / mil</th>
+                    <th>Limite total de CPF</th>
+                    <th>CPFs já utilizados</th>
+                    <th>CPFs disponíveis</th>
                     <th>Ações</th>
                 </tr>
             </thead>
@@ -33,13 +36,16 @@
                     <td>{{ c.saldo_pontos }}</td>
                     <td>R$ {{ c.valor_pago|floatformat:2 }}</td>
                     <td>R$ {{ c.valor_medio_milheiro|floatformat:2 }}</td>
+                    <td>{% if c.cpfs_total is None %}Ilimitado{% else %}{{ c.cpfs_total }}{% endif %}</td>
+                    <td>{% if c.cpfs_usados is None %}—{% else %}{{ c.cpfs_usados }}{% endif %}</td>
+                    <td>{% if c.cpfs_disponiveis is None %}Ilimitado{% else %}{{ c.cpfs_disponiveis }}{% endif %}</td>
                     <td>
                         <a href="{% url 'admin_movimentacoes' c.conta.id %}" class="btn btn--ghost">Movimentações</a>
                     </td>
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="5" class="text-center text-red-400 py-4">Nenhum programa encontrado para esta conta administrada.</td>
+                    <td colspan="8" class="text-center text-red-400 py-4">Nenhum programa encontrado para esta conta administrada.</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/gestao/templates/admin_custom/programas_do_cliente.html
+++ b/gestao/templates/admin_custom/programas_do_cliente.html
@@ -22,6 +22,9 @@
                     <th>Saldo Pontos</th>
                     <th>Valor Pago</th>
                     <th>Valor Médio / mil</th>
+                    <th>Limite total de CPF</th>
+                    <th>CPFs já utilizados</th>
+                    <th>CPFs disponíveis</th>
                     <th>Ações</th>
                 </tr>
             </thead>
@@ -32,13 +35,16 @@
                     <td>{{ c.saldo_pontos }}</td>
                     <td>R$ {{ c.valor_pago|floatformat:2 }}</td>
                     <td>R$ {{ c.valor_medio_milheiro|floatformat:2 }}</td>
+                    <td>{% if c.cpfs_total is None %}Ilimitado{% else %}{{ c.cpfs_total }}{% endif %}</td>
+                    <td>{% if c.cpfs_usados is None %}—{% else %}{{ c.cpfs_usados }}{% endif %}</td>
+                    <td>{% if c.cpfs_disponiveis is None %}Ilimitado{% else %}{{ c.cpfs_disponiveis }}{% endif %}</td>
                     <td>
                         <a href="{% url 'admin_movimentacoes' c.conta.id %}" class="btn btn--ghost">Movimentações</a>
                     </td>
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="5" class="text-center text-red-400 py-4">Nenhum programa encontrado para este cliente.</td>
+                    <td colspan="8" class="text-center text-red-400 py-4">Nenhum programa encontrado para este cliente.</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -157,6 +157,9 @@ def programas_do_cliente(request, cliente_id):
         saldo_pontos = conta.saldo_pontos
         valor_pago = conta.valor_total_pago
         valor_medio_milheiro = conta.valor_medio_por_mil
+        cpfs_usados = conta.cpfs_utilizados
+        cpfs_total = conta.quantidade_cpfs_disponiveis
+        cpfs_disponiveis = conta.cpfs_disponiveis
 
         lista_contas.append(
             {
@@ -164,6 +167,9 @@ def programas_do_cliente(request, cliente_id):
                 "saldo_pontos": saldo_pontos,
                 "valor_pago": valor_pago,
                 "valor_medio_milheiro": valor_medio_milheiro,
+                "cpfs_usados": cpfs_usados,
+                "cpfs_total": cpfs_total,
+                "cpfs_disponiveis": cpfs_disponiveis,
             }
         )
 

--- a/gestao/views/contas.py
+++ b/gestao/views/contas.py
@@ -192,6 +192,9 @@ def programas_da_conta_administrada(request, conta_id):
                 "saldo_pontos": c.saldo_pontos,
                 "valor_pago": c.valor_total_pago,
                 "valor_medio_milheiro": c.valor_medio_por_mil,
+                "cpfs_usados": c.cpfs_utilizados,
+                "cpfs_total": c.quantidade_cpfs_disponiveis,
+                "cpfs_disponiveis": c.cpfs_disponiveis,
             }
         )
     return render(

--- a/painel_cliente/static/painel_cliente/css/layout/layout.css
+++ b/painel_cliente/static/painel_cliente/css/layout/layout.css
@@ -86,6 +86,7 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transition: transform 0.3s ease;
 }
 
 .app-header {
@@ -96,6 +97,9 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 30;
 }
 
 .app-header__left {
@@ -193,6 +197,10 @@ body.sidebar-open .sidebar-overlay {
 @media (max-width: 1023px) {
   .app-shell__content {
     width: 100%;
+  }
+
+  body.sidebar-open .app-shell__content {
+    transform: translateX(256px);
   }
 }
 

--- a/painel_cliente/templates/painel_cliente/movimentacoes.html
+++ b/painel_cliente/templates/painel_cliente/movimentacoes.html
@@ -21,7 +21,13 @@
                 {% for mov in movimentacoes %}
                 <tr>
                     <td>{{ mov.data|date:"d/m/Y" }}</td>
-                    <td>{{ mov.descricao|default:"—" }}</td>
+                    <td>
+                        {% if mov.emissao_id %}
+                            <a href="{% url 'emissao_pdf' mov.emissao_id %}" class="underline">{{ mov.descricao|default:"—" }}</a>
+                        {% else %}
+                            {{ mov.descricao|default:"—" }}
+                        {% endif %}
+                    </td>
                     <td class="{% if mov.pontos >= 0 %}entrada{% else %}saida{% endif %}">
                         {{ mov.pontos }}
                     </td>


### PR DESCRIPTION
### Motivation
- Enforce a per-program limit of unique CPFs so emissions cannot consume more CPFs than a program allows.
- Centralize the CPF consumption rule in the backend and surface clear errors before any emission is persisted.
- Improve UX by showing real-time CPF consumption and available CPFs on the emission form and client program lists.
- Unify Sidebar/Header behavior between Gestão and Painel to avoid duplicated JS and ensure consistent mobile UX (overlay, push, sticky header).

### Description
- Add a dedicated service `gestao/services/cpf_limite.py` that normalizes documentos and validates CPF consumption against a program's available limit, raising `ValidationError` when exceeded.
- Enforce validation in emission flows by extracting passenger documentos (`_extract_passageiro_documentos`) and calling `validar_limite_cpfs` in `nova_emissao` and `editar_emissao`, with transactions/rollbacks on failure.
- Provide precise CPF usage data by normalizing CPFs in `ContaFidelidade.cpfs_utilizados` and extending `gestao/services/clientes_programas.py` to expose `cpfs_usados`, `cpfs_usados_list`, `cpfs_total` and `cpfs_disponiveis` to templates and frontend code.
- Add real-time frontend feedback in `form_emissao_passagem.html` JavaScript to compute how many unique CPFs the current emission will add, display availability, show error text and disable the submit button when the limit is exceeded.
- Make movimentação descriptions clickable by annotating movimentacoes with `emissao_id` (regex parse) and rendering links to the corresponding emission detail/PDF in both admin and painel templates.
- Unify sidebar/header by switching Gestão to the same data-attribute API (`data-sidebar`, `data-sidebar-open`, `data-sidebar-overlay`) and reusing the painel `app.js` module, plus CSS changes to make the mobile sidebar push content, show overlay and keep header sticky on mobile.

### Testing
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954605720d48327941900b8cda7c265)