### PR TITLE
Emissor Parceiro como tipo de emissão, limite de CPFs por programa e padronização de layout

### DIFF
--- a/gestao/models/conta_fidelidade.py
+++ b/gestao/models/conta_fidelidade.py
@@ -121,15 +121,16 @@ class ContaFidelidade(models.Model):
 
     @property
     def cpfs_utilizados(self):
-        if self.quantidade_cpfs_disponiveis is None:
+        limite = (
+            self.programa.quantidade_cpfs_disponiveis
+            if self.programa.quantidade_cpfs_disponiveis is not None
+            else self.quantidade_cpfs_disponiveis
+        )
+        if limite is None:
             return None
         from gestao.models import Passageiro
 
         filtros = {"emissao__programa_id": self.programa_id}
-        if self.cliente_id:
-            filtros["emissao__cliente_id"] = self.cliente_id
-        if self.conta_administrada_id:
-            filtros["emissao__conta_administrada_id"] = self.conta_administrada_id
         cpfs = set()
         for cpf in Passageiro.objects.filter(**filtros).values_list("cpf", flat=True):
             normalized = normalize_cpf(cpf)
@@ -139,10 +140,15 @@ class ContaFidelidade(models.Model):
 
     @property
     def cpfs_disponiveis(self):
-        if self.quantidade_cpfs_disponiveis is None:
+        limite = (
+            self.programa.quantidade_cpfs_disponiveis
+            if self.programa.quantidade_cpfs_disponiveis is not None
+            else self.quantidade_cpfs_disponiveis
+        )
+        if limite is None:
             return None
         usados = self.cpfs_utilizados or 0
-        return max(self.quantidade_cpfs_disponiveis - usados, 0)
+        return max(limite - usados, 0)
 
     @property
     def movimentacoes_compartilhadas(self):

--- a/gestao/models/emissao_passagem.py
+++ b/gestao/models/emissao_passagem.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.db import models
 from .cliente import Cliente
@@ -81,8 +82,15 @@ class EmissaoPassagem(models.Model):
 
     def save(self, *args, **kwargs):
         self.qtd_passageiros = self.qtd_adultos + self.qtd_criancas + self.qtd_bebes
-        if self.emissor_parceiro_id and self.valor_milheiro_parceiro is not None and self.valor_venda_final is not None:
-            self.lucro = self.valor_venda_final - self.valor_milheiro_parceiro
+        if (
+            self.emissor_parceiro_id
+            and self.valor_milheiro_parceiro is not None
+            and self.valor_venda_final is not None
+        ):
+            pontos = Decimal(self.pontos_utilizados or 0)
+            valor_milheiro = Decimal(self.valor_milheiro_parceiro)
+            custo_total = (pontos / Decimal("1000")) * valor_milheiro
+            self.lucro = Decimal(self.valor_venda_final) - custo_total
         elif not self.emissor_parceiro_id:
             self.lucro = None
         super().save(*args, **kwargs)

--- a/gestao/services/cpf_limite.py
+++ b/gestao/services/cpf_limite.py
@@ -4,22 +4,16 @@ from typing import Iterable, Set, Tuple
 
 from django.core.exceptions import ValidationError
 
-from gestao.models import Passageiro
+from gestao.models import Passageiro, ProgramaFidelidade
 from gestao.utils import normalize_cpf
 
 
 def _build_existing_cpfs(
     *,
     programa_id: int,
-    cliente_id: int | None = None,
-    conta_administrada_id: int | None = None,
     exclude_emissao_id: int | None = None,
 ) -> Set[str]:
     filtros = {"emissao__programa_id": programa_id}
-    if cliente_id:
-        filtros["emissao__cliente_id"] = cliente_id
-    if conta_administrada_id:
-        filtros["emissao__conta_administrada_id"] = conta_administrada_id
 
     qs = Passageiro.objects.filter(**filtros)
     if exclude_emissao_id:
@@ -42,17 +36,26 @@ def _normalize_cpfs(cpfs: Iterable[str]) -> Set[str]:
     return normalized_cpfs
 
 
-def validar_limite_cpfs(conta, cpfs: Iterable[str], emissao_id: int | None = None) -> Tuple[int, int | None]:
+def _get_limite_programa(programa: ProgramaFidelidade) -> int | None:
+    return programa.quantidade_cpfs_disponiveis
+
+
+def validar_limite_cpfs(
+    conta_ou_programa, cpfs: Iterable[str], emissao_id: int | None = None
+) -> Tuple[int, int | None]:
     """Valida o consumo de CPFs e retorna (cpfs_novos, cpfs_disponiveis)."""
 
-    limite = conta.quantidade_cpfs_disponiveis
+    programa = (
+        conta_ou_programa.programa
+        if hasattr(conta_ou_programa, "programa")
+        else conta_ou_programa
+    )
+    limite = _get_limite_programa(programa)
     if limite is None:
         return 0, None
 
     cpfs_existentes = _build_existing_cpfs(
-        programa_id=conta.programa_id,
-        cliente_id=conta.cliente_id,
-        conta_administrada_id=conta.conta_administrada_id,
+        programa_id=programa.id,
         exclude_emissao_id=emissao_id,
     )
     cpfs_na_emissao = _normalize_cpfs(cpfs)

--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -38,10 +38,12 @@ body {
   background: var(--bg);
 }
 
+.fpp-container,
 .page-container {
   max-width: var(--page-max-width);
   margin: 0 auto;
   width: 100%;
+  padding: 0 24px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -125,10 +127,9 @@ a:hover {
 }
 
 .page-shell {
-  max-width: var(--page-max-width);
+  width: 100%;
   margin: 0;
   padding: 0 0 2.5rem;
-  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/gestao/templates/admin_custom/emissao_detalhe.html
+++ b/gestao/templates/admin_custom/emissao_detalhe.html
@@ -66,11 +66,11 @@
         <p class="value">{% if emissao.economia_obtida %}R$ {{ emissao.economia_obtida|floatformat:2 }}{% else %}—{% endif %}</p>
       </div>
       <div>
-        <p class="label">Custo parceiro</p>
+        <p class="label">Valor do milheiro parceiro</p>
         <p class="value">{% if emissao.valor_milheiro_parceiro %}R$ {{ emissao.valor_milheiro_parceiro|floatformat:2 }}{% else %}—{% endif %}</p>
       </div>
       <div>
-        <p class="label">Venda ao cliente</p>
+        <p class="label">Valor final ao cliente</p>
         <p class="value">{% if emissao.valor_venda_final %}R$ {{ emissao.valor_venda_final|floatformat:2 }}{% else %}—{% endif %}</p>
       </div>
       <div>

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -43,9 +43,9 @@
         </div>
         <div class="form-grid form-grid--3">
             <div>
-                <label class="form-label" for="{{ form.tipo_titular.id_for_label }}">Tipo de emissão <span class="required-asterisk">*</span></label>
-                {{ form.tipo_titular }}
-                <p class="helper-text">Defina se a emissão usa cliente ou conta administrada.</p>
+                <label class="form-label" for="{{ form.tipo_emissao.id_for_label }}">Tipo de emissão <span class="required-asterisk">*</span></label>
+                {{ form.tipo_emissao }}
+                <p class="helper-text">Selecione a origem da emissão: cliente, conta administrada ou emissor parceiro.</p>
             </div>
             <div id="cliente-wrapper" class="form-field--center">
                 <label class="form-label" for="{{ form.cliente.id_for_label }}">Cliente <span class="required-asterisk">*</span></label>
@@ -58,15 +58,16 @@
             </div>
         </div>
         <div class="form-grid form-grid--3">
-            <div>
+            <div id="emissor-parceiro-wrapper">
                 <label class="form-label" for="{{ form.emissor_parceiro.id_for_label }}">Emissor parceiro</label>
                 {{ form.emissor_parceiro }}
-                <p class="helper-text">Opcional. Se selecionado, o programa virá do parceiro.</p>
+                <p class="helper-text">Obrigatório quando o tipo de emissão for emissor parceiro.</p>
             </div>
             <div>
                 <label class="form-label" for="{{ form.programa.id_for_label }}">Programa <span class="required-asterisk">*</span></label>
                 {{ form.programa }}
                 <p id="programa-info" class="helper-text mt-1"></p>
+                <p id="cpf-usados-info" class="helper-text mt-1"></p>
                 <p id="cpf-consumo-info" class="helper-text mt-1"></p>
                 <p id="cpf-limite-error" class="helper-text mt-1 text-red-500"></p>
             </div>
@@ -227,7 +228,7 @@
                 {{ form.pontos_utilizados }}
             </div>
             <div class="form-field--compact">
-                <label class="form-label" for="{{ form.valor_referencia_pontos.id_for_label }}">Valor do milheiro (R$)</label>
+                <label class="form-label" for="{{ form.valor_referencia_pontos.id_for_label }}">Custo das milhas (R$)</label>
                 {{ form.valor_referencia_pontos }}
             </div>
             <div class="form-field--compact">
@@ -236,16 +237,16 @@
             </div>
         </div>
         <div class="form-grid form-grid--3">
-            <div class="form-field--compact">
-                <label class="form-label" for="{{ form.valor_milheiro_parceiro.id_for_label }}">Custo do parceiro (R$)</label>
+            <div class="form-field--compact" id="valor-milheiro-parceiro-wrapper">
+                <label class="form-label" for="{{ form.valor_milheiro_parceiro.id_for_label }}">Valor do milheiro (R$)</label>
                 {{ form.valor_milheiro_parceiro }}
-                <p class="helper-text">Obrigatório quando houver emissor parceiro.</p>
+                <p class="helper-text">Obrigatório para emissor parceiro.</p>
             </div>
-            <div class="form-field--compact">
-                <label class="form-label" for="{{ form.valor_venda_final.id_for_label }}">Venda ao cliente (R$)</label>
+            <div class="form-field--compact" id="valor-venda-final-wrapper">
+                <label class="form-label" for="{{ form.valor_venda_final.id_for_label }}">Valor final ao cliente (R$)</label>
                 {{ form.valor_venda_final }}
             </div>
-            <div class="form-field--compact">
+            <div class="form-field--compact" id="lucro-wrapper">
                 <label class="form-label" for="{{ form.lucro.id_for_label }}">Lucro (R$)</label>
                 {{ form.lucro }}
             </div>
@@ -297,18 +298,24 @@ const aeroportos = {{ aeroportos_json|safe }};
 const clienteProgramas = {{ cliente_programas_json|safe }};
 const contasAdmProgramas = {{ contas_adm_programas_json|safe }};
 const emissorParceiroProgramas = {{ emissor_parceiros_json|safe }};
+const programasParceiro = {{ programas_parceiros_json|safe }};
 
 const passageirosContainer = document.getElementById('passageiros-container');
 const clienteSelect = document.getElementById('id_cliente');
 const programaSelect = document.getElementById('id_programa');
 const programaInfo = document.getElementById('programa-info');
+const cpfUsadosInfo = document.getElementById('cpf-usados-info');
 const cpfConsumoInfo = document.getElementById('cpf-consumo-info');
 const cpfLimiteError = document.getElementById('cpf-limite-error');
-const tipoTitularSelect = document.getElementById('id_tipo_titular');
+const tipoEmissaoSelect = document.getElementById('id_tipo_emissao');
 const contaAdmSelect = document.getElementById('id_conta_administrada');
 const emissorParceiroSelect = document.getElementById('id_emissor_parceiro');
 const clienteWrapper = document.getElementById('cliente-wrapper');
 const contaAdmWrapper = document.getElementById('conta-adm-wrapper');
+const emissorParceiroWrapper = document.getElementById('emissor-parceiro-wrapper');
+const valorMilheiroParceiroWrapper = document.getElementById('valor-milheiro-parceiro-wrapper');
+const valorVendaFinalWrapper = document.getElementById('valor-venda-final-wrapper');
+const lucroWrapper = document.getElementById('lucro-wrapper');
 const pontosField = document.getElementById('id_pontos_utilizados');
 const valorRefPontosField = document.getElementById('id_valor_referencia_pontos');
 const valorReferenciaField = document.getElementById('id_valor_referencia');
@@ -328,6 +335,9 @@ const dataVoltaField = document.getElementById('id_data_volta');
 
 if (lucroField) {
     lucroField.readOnly = true;
+}
+if (valorRefPontosField) {
+    valorRefPontosField.readOnly = true;
 }
 
 function setVoltaVisibility() {
@@ -349,22 +359,26 @@ if (possuiVoltaToggle) {
     });
 }
 
+function getTipoEmissao() {
+    return tipoEmissaoSelect ? tipoEmissaoSelect.value : "cliente";
+}
+
 function getProgramasDisponiveis() {
-    const tipo = tipoTitularSelect ? tipoTitularSelect.value : "cliente";
-    let programas = [];
+    const tipo = getTipoEmissao();
+    if (tipo === "parceiro") {
+        const emissorId = emissorParceiroSelect ? emissorParceiroSelect.value : null;
+        if (!emissorId || !emissorParceiroProgramas || !programasParceiro) {
+            return [];
+        }
+        const allowedIds = emissorParceiroProgramas[emissorId] || [];
+        return programasParceiro.filter((p) => allowedIds.includes(p.id));
+    }
     if (tipo === "administrada") {
         const contaId = contaAdmSelect ? contaAdmSelect.value : null;
-        programas = (contasAdmProgramas && contaId) ? (contasAdmProgramas[contaId] || []) : [];
-    } else {
-        const clienteId = clienteSelect ? clienteSelect.value : null;
-        programas = (clienteProgramas && clienteId) ? (clienteProgramas[clienteId] || []) : [];
+        return (contasAdmProgramas && contaId) ? (contasAdmProgramas[contaId] || []) : [];
     }
-    const emissorId = emissorParceiroSelect ? emissorParceiroSelect.value : null;
-    if (emissorId && emissorParceiroProgramas && emissorParceiroProgramas[emissorId]) {
-        const allowedIds = emissorParceiroProgramas[emissorId];
-        programas = programas.filter((p) => allowedIds.includes(p.id));
-    }
-    return programas;
+    const clienteId = clienteSelect ? clienteSelect.value : null;
+    return (clienteProgramas && clienteId) ? (clienteProgramas[clienteId] || []) : [];
 }
 
 function updateProgramaInfo() {
@@ -375,11 +389,23 @@ function updateProgramaInfo() {
         const cpfsTxt = selected.cpfs_total === null || selected.cpfs_total === undefined
             ? "CPFs disponíveis: ilimitado"
             : `CPFs disponíveis: ${selected.cpfs_disponiveis} de ${selected.cpfs_total}`;
-        programaInfo.textContent = `Saldo: ${selected.saldo} pontos • Custo médio: R$ ${Number(selected.valor_medio || 0).toFixed(2)} • ${cpfsTxt}`;
+        if (selected.saldo !== undefined) {
+            programaInfo.textContent = `Saldo: ${selected.saldo} pontos • Custo médio: R$ ${Number(selected.valor_medio || 0).toFixed(2)} • ${cpfsTxt}`;
+        } else {
+            programaInfo.textContent = `Referência do milheiro: R$ ${Number(selected.valor_medio || 0).toFixed(2)} • ${cpfsTxt}`;
+        }
+        if (cpfUsadosInfo) {
+            const usadosList = selected.cpfs_usados_list || [];
+            cpfUsadosInfo.textContent = usadosList.length
+                ? `CPFs usados no programa: ${usadosList.join(", ")}`
+                : "CPFs usados no programa: nenhum";
+        }
     } else if (programas.length) {
         programaInfo.textContent = "Nenhum programa disponível para o titular selecionado.";
+        if (cpfUsadosInfo) cpfUsadosInfo.textContent = "";
     } else {
         programaInfo.textContent = "";
+        if (cpfUsadosInfo) cpfUsadosInfo.textContent = "";
     }
     updateCpfLimite();
     recalcValoresFinanceiros();
@@ -406,8 +432,12 @@ function recalcValoresFinanceiros() {
     const programas = getProgramasDisponiveis();
     const selected = programas.find(p => String(p.id) === (programaSelect ? programaSelect.value : ""));
     const pontos = parseFloat(pontosField ? (pontosField.value || 0) : 0);
-    if (selected && valorRefPontosField) {
-        const valorRefPontos = (pontos / 1000) * (selected.valor_medio || 0);
+    const tipo = getTipoEmissao();
+    const valorMilheiro = tipo === "parceiro"
+        ? parseFloat(custoParceiroField ? (custoParceiroField.value || 0) : 0)
+        : (selected ? (selected.valor_medio || 0) : 0);
+    const valorRefPontos = (pontos / 1000) * (valorMilheiro || 0);
+    if (valorRefPontosField) {
         valorRefPontosField.value = valorRefPontos.toFixed(2);
     }
     const valorRef = parseFloat(valorReferenciaField ? (valorReferenciaField.value || 0) : 0);
@@ -416,24 +446,53 @@ function recalcValoresFinanceiros() {
     if (economiaField) {
         economiaField.value = (valorRef - (valorPago + valorRefPts)).toFixed(2);
     }
-    updateLucro();
+    updateLucro(valorRefPontos);
     updateResumoVisual();
 }
 
-function updateLucro() {
+function updateLucro(custoTotal) {
     if (!lucroField) return;
-    const custo = parseFloat(custoParceiroField ? (custoParceiroField.value || 0) : 0);
+    if (getTipoEmissao() !== "parceiro") {
+        lucroField.value = "";
+        return;
+    }
+    const custo = parseFloat(valorRefPontosField ? (valorRefPontosField.value || 0) : 0);
     const venda = parseFloat(vendaFinalField ? (vendaFinalField.value || 0) : 0);
-    if (custo || venda) {
-        lucroField.value = (venda - custo).toFixed(2);
+    const custoBase = custoTotal !== undefined ? custoTotal : custo;
+    if (custoBase || venda) {
+        lucroField.value = (venda - custoBase).toFixed(2);
     }
 }
 
 function toggleTitularFields() {
-    const tipo = tipoTitularSelect ? tipoTitularSelect.value : "cliente";
+    const tipo = getTipoEmissao();
     if (clienteWrapper && contaAdmWrapper) {
         clienteWrapper.style.display = "block";
         contaAdmWrapper.style.display = tipo === "administrada" ? "block" : "none";
+    }
+    if (emissorParceiroWrapper) {
+        emissorParceiroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+    }
+    if (valorMilheiroParceiroWrapper) {
+        valorMilheiroParceiroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+    }
+    if (valorVendaFinalWrapper) {
+        valorVendaFinalWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+    }
+    if (lucroWrapper) {
+        lucroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+    }
+    if (tipo !== "parceiro" && emissorParceiroSelect) {
+        emissorParceiroSelect.value = "";
+    }
+    if (tipo !== "parceiro" && custoParceiroField) {
+        custoParceiroField.value = "";
+    }
+    if (tipo !== "parceiro" && vendaFinalField) {
+        vendaFinalField.value = "";
+    }
+    if (tipo !== "parceiro" && lucroField) {
+        lucroField.value = "";
     }
     updateProgramaOptions();
 }
@@ -444,8 +503,8 @@ if (clienteSelect) {
 if (contaAdmSelect) {
     contaAdmSelect.addEventListener('change', updateProgramaOptions);
 }
-if (tipoTitularSelect) {
-    tipoTitularSelect.addEventListener('change', toggleTitularFields);
+if (tipoEmissaoSelect) {
+    tipoEmissaoSelect.addEventListener('change', toggleTitularFields);
 }
 if (emissorParceiroSelect) {
     emissorParceiroSelect.addEventListener('change', updateProgramaOptions);
@@ -463,10 +522,10 @@ if (valorPagoField) {
     valorPagoField.addEventListener('input', recalcValoresFinanceiros);
 }
 if (custoParceiroField) {
-    custoParceiroField.addEventListener('input', updateLucro);
+    custoParceiroField.addEventListener('input', recalcValoresFinanceiros);
 }
 if (vendaFinalField) {
-    vendaFinalField.addEventListener('input', updateLucro);
+    vendaFinalField.addEventListener('input', recalcValoresFinanceiros);
 }
 
 function renderPassengerForms() {

--- a/gestao/tests/test_emissao_views.py
+++ b/gestao/tests/test_emissao_views.py
@@ -32,7 +32,7 @@ class NovaEmissaoViewTest(TestCase):
 
     def _post_payload(self, extra=None):
         payload = {
-            "tipo_titular": "cliente",
+            "tipo_emissao": "cliente",
             "cliente": str(self.cliente.id),
             "programa": str(self.programa.id),
             "aeroporto_partida": str(self.aeroporto_origem.id),
@@ -79,7 +79,7 @@ class NovaEmissaoViewTest(TestCase):
 
         payload = self._post_payload(
             {
-                "tipo_titular": "administrada",
+                "tipo_emissao": "administrada",
                 "conta_administrada": str(conta_adm.id),
                 "cliente": str(self.cliente.id),
             }

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -158,7 +158,7 @@ def programas_do_cliente(request, cliente_id):
         valor_pago = conta.valor_total_pago
         valor_medio_milheiro = conta.valor_medio_por_mil
         cpfs_usados = conta.cpfs_utilizados
-        cpfs_total = conta.quantidade_cpfs_disponiveis
+        cpfs_total = conta.programa.quantidade_cpfs_disponiveis
         cpfs_disponiveis = conta.cpfs_disponiveis
 
         lista_contas.append(

--- a/gestao/views/contas.py
+++ b/gestao/views/contas.py
@@ -193,7 +193,7 @@ def programas_da_conta_administrada(request, conta_id):
                 "valor_pago": c.valor_total_pago,
                 "valor_medio_milheiro": c.valor_medio_por_mil,
                 "cpfs_usados": c.cpfs_utilizados,
-                "cpfs_total": c.quantidade_cpfs_disponiveis,
+                "cpfs_total": c.programa.quantidade_cpfs_disponiveis,
                 "cpfs_disponiveis": c.cpfs_disponiveis,
             }
         )


### PR DESCRIPTION
### Motivation
- Padronizar o layout da Gestão com o mesmo container e espaçamento do Painel do Cliente para garantir consistência visual e leitura confortável.
- Tratar o emissor parceiro como um novo `tipo de emissão` em vez de vinculá-lo diretamente à conta, com campos e cálculos próprios.
- Corrigir o bug crítico de limite de CPFs passando a considerar o histórico completo do programa e não apenas a emissão atual.
- Expor no frontend os CPFs usados/disponíveis e bloquear a emissão quando o limite do programa for excedido.

### Description
- Backend: refatorei `gestao.services.cpf_limite.validar_limite_cpfs` para operar por `ProgramaFidelidade` e contar CPFs históricos, e adicionei `_get_limite_programa` para centralizar o limite; também atualizei `ContaFidelidade.cpfs_utilizados`/`cpfs_disponiveis` para respeitar o limite do programa.
- Mapas e serviços: adaptei `gestao.services.clientes_programas` para agrupar CPFs por `programa_id` e adicionei `build_programas_fidelidade_map` para fornecer dados consolidados ao frontend.
- Emissão: passei a tratar `Emissor Parceiro` como `tipo_emissao` no `EmissaoPassagemForm` e no template/JS, ajustei `EmissaoPassagem.save` para calcular `lucro = valor_venda_final - (pontos/1000 * valor_milheiro_parceiro)`, e atualizei `gestao.views.emissoes` para validar limites por programa e condicionar o registro de movimentações.
- Frontend/layout: alterei `form_emissao_passagem.html` e seu JS para suportar o fluxo de `tipo_emissao` (cliente/administrada/parceiro), mostrar lista de programas do parceiro, exibir CPFs usados, calcular automaticamente custos e lucro, e padronizei o container no `gestao/static/gestao/css/admin-theme.css`.

### Testing
- Iniciado o servidor de desenvolvimento com `python manage.py runserver`, que iniciou com sucesso porém exibiu aviso de migrações pendentes (migrations não aplicadas). 
- Criado usuário admin via `python manage.py shell` com sucesso para testes manuais do painel. 
- Executada captura de tela via Playwright para verificar a página de login/admin; a primeira tentativa expirou por timeout, e uma tentativa subsequente conseguiu gerar a captura da tela de login do admin. 
- Não foram executados testes unitários automáticos (`manage.py test` / `pytest`) durante este rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695474dba7bc83278493ecc52a6efa14)