### PR TITLE
Unificar layout e Dark Mode; aplicar limite de CPFs por conta; ajustar fluxo Emissor Parceiro

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -10,7 +10,7 @@
 </head>
 <body class="login-page">
   <div class="login-container">
-    <button class="dark-mode-toggle" id="darkModeToggle" type="button" aria-label="Alternar modo escuro">🌙</button>
+    <button class="dark-mode-toggle" type="button" data-theme-toggle aria-label="Alternar modo escuro">🌙</button>
     <img src="{% static 'painel_cliente/ncfly_logo.png' %}" alt="Logo NCfly" class="login-logo">
     <h2>Bem-vindo ao NCfly</h2>
     {% if messages %}
@@ -36,21 +36,6 @@
       <button type="submit">Entrar</button>
     </form>
   </div>
-  <script>
-    const darkModeToggle = document.getElementById('darkModeToggle');
-    const savedMode = localStorage.getItem('darkMode');
-
-    if (savedMode === 'enabled') {
-      document.body.classList.add('dark-mode');
-      darkModeToggle.textContent = '☀️';
-    }
-
-    darkModeToggle.addEventListener('click', () => {
-      document.body.classList.toggle('dark-mode');
-      const isDark = document.body.classList.contains('dark-mode');
-      localStorage.setItem('darkMode', isDark ? 'enabled' : 'disabled');
-      darkModeToggle.textContent = isDark ? '☀️' : '🌙';
-    });
-  </script>
+  <script type="module" src="{% static 'painel_cliente/js/app.js' %}" defer></script>
 </body>
 </html>

--- a/gestao/models/conta_fidelidade.py
+++ b/gestao/models/conta_fidelidade.py
@@ -121,16 +121,17 @@ class ContaFidelidade(models.Model):
 
     @property
     def cpfs_utilizados(self):
-        limite = (
-            self.programa.quantidade_cpfs_disponiveis
-            if self.programa.quantidade_cpfs_disponiveis is not None
-            else self.quantidade_cpfs_disponiveis
-        )
+        limite = self.quantidade_cpfs_disponiveis
         if limite is None:
             return None
         from gestao.models import Passageiro
 
         filtros = {"emissao__programa_id": self.programa_id}
+        if self.cliente_id:
+            filtros["emissao__cliente_id"] = self.cliente_id
+            filtros["emissao__conta_administrada__isnull"] = True
+        if self.conta_administrada_id:
+            filtros["emissao__conta_administrada_id"] = self.conta_administrada_id
         cpfs = set()
         for cpf in Passageiro.objects.filter(**filtros).values_list("cpf", flat=True):
             normalized = normalize_cpf(cpf)
@@ -140,11 +141,7 @@ class ContaFidelidade(models.Model):
 
     @property
     def cpfs_disponiveis(self):
-        limite = (
-            self.programa.quantidade_cpfs_disponiveis
-            if self.programa.quantidade_cpfs_disponiveis is not None
-            else self.quantidade_cpfs_disponiveis
-        )
+        limite = self.quantidade_cpfs_disponiveis
         if limite is None:
             return None
         usados = self.cpfs_utilizados or 0

--- a/gestao/models/emissao_passagem.py
+++ b/gestao/models/emissao_passagem.py
@@ -82,16 +82,12 @@ class EmissaoPassagem(models.Model):
 
     def save(self, *args, **kwargs):
         self.qtd_passageiros = self.qtd_adultos + self.qtd_criancas + self.qtd_bebes
-        if (
-            self.emissor_parceiro_id
-            and self.valor_milheiro_parceiro is not None
-            and self.valor_venda_final is not None
-        ):
+        if self.valor_milheiro_parceiro is not None and self.valor_venda_final is not None:
             pontos = Decimal(self.pontos_utilizados or 0)
             valor_milheiro = Decimal(self.valor_milheiro_parceiro)
             custo_total = (pontos / Decimal("1000")) * valor_milheiro
             self.lucro = Decimal(self.valor_venda_final) - custo_total
-        elif not self.emissor_parceiro_id:
+        elif self.valor_venda_final is None:
             self.lucro = None
         super().save(*args, **kwargs)
 

--- a/gestao/services/clientes_programas.py
+++ b/gestao/services/clientes_programas.py
@@ -1,16 +1,14 @@
 """Serviços para mapear programas vinculados a clientes."""
 
 from typing import Dict, List
-from django.db.models import Count, Q
+from django.db.models import Q
 
-from gestao.models import ContaFidelidade, EmissaoPassagem, Passageiro, ProgramaFidelidade
+from gestao.models import ContaFidelidade, EmissaoPassagem, Passageiro
 from gestao.utils import normalize_cpf
 
-Key = int
 
-
-def _build_cpfs_map(empresa_id=None) -> Dict[Key, int]:
-    """Retorna um mapa programa_id -> CPFs distintos usados."""
+def _build_cpfs_sets_map(empresa_id=None, exclude_emissao_id=None) -> Dict[tuple, set]:
+    """Retorna um mapa (tipo, titular_id, programa_id) -> conjunto de CPFs normalizados."""
 
     filtros = Q(emissao__programa__isnull=False)
     if empresa_id:
@@ -18,42 +16,41 @@ def _build_cpfs_map(empresa_id=None) -> Dict[Key, int]:
             Q(emissao__cliente__empresa_id=empresa_id)
             | Q(emissao__conta_administrada__empresa_id=empresa_id)
         )
-    cpfs_qs = (
-        Passageiro.objects.filter(filtros)
-        .values("emissao__programa_id")
-        .annotate(qtd=Count("cpf", distinct=True))
+    cpfs_map: Dict[tuple, set] = {}
+
+    clientes_qs = Passageiro.objects.filter(
+        filtros, emissao__conta_administrada__isnull=True
     )
-    return {row["emissao__programa_id"]: row["qtd"] for row in cpfs_qs}
-
-
-def _build_cpfs_sets_map(empresa_id=None, exclude_emissao_id=None) -> Dict[Key, set]:
-    """Retorna um mapa programa_id -> conjunto de CPFs normalizados."""
-
-    filtros = Q(emissao__programa__isnull=False)
-    if empresa_id:
-        filtros &= (
-            Q(emissao__cliente__empresa_id=empresa_id)
-            | Q(emissao__conta_administrada__empresa_id=empresa_id)
-        )
-    cpfs_qs = Passageiro.objects.filter(filtros)
+    contas_adm_qs = Passageiro.objects.filter(
+        filtros, emissao__conta_administrada__isnull=False
+    )
     if exclude_emissao_id:
-        cpfs_qs = cpfs_qs.exclude(emissao_id=exclude_emissao_id)
-    cpfs_map: Dict[Key, set] = {}
-    for row in cpfs_qs.values("emissao__programa_id", "cpf"):
-        key = row["emissao__programa_id"]
+        clientes_qs = clientes_qs.exclude(emissao_id=exclude_emissao_id)
+        contas_adm_qs = contas_adm_qs.exclude(emissao_id=exclude_emissao_id)
+
+    for row in clientes_qs.values("emissao__cliente_id", "emissao__programa_id", "cpf"):
+        key = ("cliente", row["emissao__cliente_id"], row["emissao__programa_id"])
         normalized = normalize_cpf(row["cpf"])
-        if not normalized:
-            continue
-        cpfs_map.setdefault(key, set()).add(normalized)
+        if normalized:
+            cpfs_map.setdefault(key, set()).add(normalized)
+
+    for row in contas_adm_qs.values(
+        "emissao__conta_administrada_id", "emissao__programa_id", "cpf"
+    ):
+        key = (
+            "administrada",
+            row["emissao__conta_administrada_id"],
+            row["emissao__programa_id"],
+        )
+        normalized = normalize_cpf(row["cpf"])
+        if normalized:
+            cpfs_map.setdefault(key, set()).add(normalized)
+
     return cpfs_map
 
 
 def _get_limite_cpfs(conta: ContaFidelidade) -> int | None:
-    return (
-        conta.programa.quantidade_cpfs_disponiveis
-        if conta.programa.quantidade_cpfs_disponiveis is not None
-        else conta.quantidade_cpfs_disponiveis
-    )
+    return conta.quantidade_cpfs_disponiveis
 
 
 def build_clientes_programas_map(
@@ -73,7 +70,7 @@ def build_clientes_programas_map(
     cpfs_sets_map = _build_cpfs_sets_map(empresa_id, exclude_emissao_id)
     data = {}
     for conta in contas:
-        key = conta.programa_id
+        key = ("cliente", conta.cliente_id, conta.programa_id)
         cpfs_usados_list = sorted(cpfs_sets_map.get(key, set()))
         cpfs_usados = len(cpfs_usados_list)
         limite_cpfs = _get_limite_cpfs(conta)
@@ -102,10 +99,10 @@ def build_clientes_programas_map(
                     "nome": str(instance.programa),
                     "saldo": 0,
                     "valor_medio": 0,
-                    "cpfs_disponiveis": instance.programa.quantidade_cpfs_disponiveis,
-                    "cpfs_total": instance.programa.quantidade_cpfs_disponiveis,
-                    "cpfs_usados": len(cpfs_sets_map.get(instance.programa_id, set())),
-                    "cpfs_usados_list": sorted(cpfs_sets_map.get(instance.programa_id, set())),
+                    "cpfs_disponiveis": None,
+                    "cpfs_total": None,
+                    "cpfs_usados": len(cpfs_sets_map.get(("cliente", instance.cliente_id, instance.programa_id), set())),
+                    "cpfs_usados_list": sorted(cpfs_sets_map.get(("cliente", instance.cliente_id, instance.programa_id), set())),
                 }
             )
     return data
@@ -128,7 +125,7 @@ def build_contas_administradas_programas_map(
     cpfs_sets_map = _build_cpfs_sets_map(empresa_id, exclude_emissao_id)
     data: Dict[int, List[dict]] = {}
     for conta in contas:
-        key = conta.programa_id
+        key = ("administrada", conta.conta_administrada_id, conta.programa_id)
         cpfs_usados_list = sorted(cpfs_sets_map.get(key, set()))
         cpfs_usados = len(cpfs_usados_list)
         limite_cpfs = _get_limite_cpfs(conta)
@@ -157,36 +154,20 @@ def build_contas_administradas_programas_map(
                     "nome": str(instance.programa),
                     "saldo": 0,
                     "valor_medio": 0,
-                    "cpfs_disponiveis": instance.programa.quantidade_cpfs_disponiveis,
-                    "cpfs_total": instance.programa.quantidade_cpfs_disponiveis,
-                    "cpfs_usados": len(cpfs_sets_map.get(instance.programa_id, set())),
-                    "cpfs_usados_list": sorted(cpfs_sets_map.get(instance.programa_id, set())),
+                    "cpfs_disponiveis": None,
+                    "cpfs_total": None,
+                    "cpfs_usados": len(
+                        cpfs_sets_map.get(
+                            ("administrada", instance.conta_administrada_id, instance.programa_id),
+                            set(),
+                        )
+                    ),
+                    "cpfs_usados_list": sorted(
+                        cpfs_sets_map.get(
+                            ("administrada", instance.conta_administrada_id, instance.programa_id),
+                            set(),
+                        )
+                    ),
                 }
             )
-    return data
-
-
-def build_programas_fidelidade_map(
-    empresa_id=None, exclude_emissao_id=None
-) -> List[dict]:
-    """Retorna uma lista de programas com informações de CPFs consolidadas."""
-
-    programas = ProgramaFidelidade.objects.all().order_by("nome")
-    cpfs_sets_map = _build_cpfs_sets_map(empresa_id, exclude_emissao_id)
-    data: List[dict] = []
-    for programa in programas:
-        cpfs_usados_list = sorted(cpfs_sets_map.get(programa.id, set()))
-        limite_cpfs = programa.quantidade_cpfs_disponiveis
-        cpfs_disponiveis = None if limite_cpfs is None else max(limite_cpfs - len(cpfs_usados_list), 0)
-        data.append(
-            {
-                "id": programa.id,
-                "nome": programa.nome,
-                "valor_medio": float(programa.preco_medio_milheiro or 0),
-                "cpfs_disponiveis": cpfs_disponiveis,
-                "cpfs_total": limite_cpfs,
-                "cpfs_usados": len(cpfs_usados_list),
-                "cpfs_usados_list": cpfs_usados_list,
-            }
-        )
     return data

--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -12,7 +12,7 @@
   --danger: #dc2626;
   --radius: 16px;
   --shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
-  --page-max-width: 1280px;
+  --page-max-width: 100%;
 }
 
 body {
@@ -20,6 +20,21 @@ body {
   color: var(--heading);
   font-family: 'Open Sans', sans-serif;
   display: block;
+}
+
+body.dark-mode {
+  --bg: #0f172a;
+  --surface: #111827;
+  --border: #1f2937;
+  --muted: #94a3b8;
+  --heading: #f8fafc;
+  --primary: #60a5fa;
+  --primary-strong: #3b82f6;
+  --accent: #38bdf8;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #f87171;
+  --shadow: 0 14px 30px rgba(15, 23, 42, 0.45);
 }
 
 /* ===== Layout base ===== */
@@ -40,10 +55,10 @@ body {
 
 .fpp-container,
 .page-container {
-  max-width: var(--page-max-width);
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   width: 100%;
-  padding: 0 24px;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/gestao/static/gestao/css/base/variables.css
+++ b/gestao/static/gestao/css/base/variables.css
@@ -1,4 +1,34 @@
 :root {
+  --color-bg: #f7fafc;
+  --color-text: #1a202c;
+  --color-heading: #1a365d;
+  --color-primary: #3182ce;
+  --color-primary-dark: #2c5282;
+  --color-muted: #4a5568;
+  --color-border: #e2e8f0;
+  --color-success: #2f855a;
   --color-danger: #dc2626;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f9fafb;
+  --color-surface-active: #ebf4ff;
+  --color-input-bg: #edf2f7;
+  --color-input-border: #cbd5e0;
   --radius-lg: 0.75rem;
+}
+
+body.dark-mode {
+  --color-bg: #0f172a;
+  --color-text: #e2e8f0;
+  --color-heading: #f8fafc;
+  --color-primary: #60a5fa;
+  --color-primary-dark: #3b82f6;
+  --color-muted: #94a3b8;
+  --color-border: #1f2937;
+  --color-success: #22c55e;
+  --color-danger: #f87171;
+  --color-surface: #111827;
+  --color-surface-muted: #1f2937;
+  --color-surface-active: #1d4ed8;
+  --color-input-bg: #1f2937;
+  --color-input-border: #374151;
 }

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -200,7 +200,10 @@
             </div>
             <div class="app-header__actions">
                 <span class="user-name">{{ request.user.get_full_name|default:request.user.username }}</span>
-                <a href="{% url 'logout' %}" class="btn btn--outline btn--sm">Logout</a>
+                <button class="icon-button" type="button" data-theme-toggle aria-label="Alternar modo escuro">🌙</button>
+                <form action="{% url 'logout' %}" method="post">{% csrf_token %}
+                    <button class="btn btn--outline btn--sm" type="submit">Logout</button>
+                </form>
             </div>
         </header>
 

--- a/gestao/templates/admin_custom/emissores_parceiros.html
+++ b/gestao/templates/admin_custom/emissores_parceiros.html
@@ -20,7 +20,6 @@
             <thead>
                 <tr>
                     <th>Nome</th>
-                    <th>Programas disponíveis</th>
                     <th>Status</th>
                     <th>Ações</th>
                 </tr>
@@ -29,13 +28,6 @@
                 {% for emissor in emissores %}
                 <tr>
                     <td>{{ emissor.nome }}</td>
-                    <td>
-                        {% for programa in emissor.programas.all %}
-                            {{ programa.nome }}{% if not forloop.last %}, {% endif %}
-                        {% empty %}
-                            —
-                        {% endfor %}
-                    </td>
                     <td>{% if emissor.ativo %}Ativo{% else %}Inativo{% endif %}</td>
                     <td>
                         <div class="page-actions">
@@ -46,7 +38,7 @@
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="4" class="p-3 text-center text-zinc-400">Nenhum emissor parceiro cadastrado.</td>
+                    <td colspan="3" class="p-3 text-center text-zinc-400">Nenhum emissor parceiro cadastrado.</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -52,9 +52,9 @@
                 {{ form.cliente }}
             </div>
             <div id="conta-adm-wrapper">
-                <label class="form-label" for="{{ form.conta_administrada.id_for_label }}">Conta administrada</label>
+                <label class="form-label" for="{{ form.conta_administrada.id_for_label }}">Conta administrada <span class="required-asterisk">*</span></label>
                 {{ form.conta_administrada }}
-                <p class="helper-text">Aparece apenas quando o titular for administrado.</p>
+                <p class="helper-text">Aparece quando a emissão usa conta administrada ou emissor parceiro.</p>
             </div>
         </div>
         <div class="form-grid form-grid--3">
@@ -240,7 +240,7 @@
             <div class="form-field--compact" id="valor-milheiro-parceiro-wrapper">
                 <label class="form-label" for="{{ form.valor_milheiro_parceiro.id_for_label }}">Valor do milheiro (R$)</label>
                 {{ form.valor_milheiro_parceiro }}
-                <p class="helper-text">Obrigatório para emissor parceiro.</p>
+                <p class="helper-text">Preenchido automaticamente para contas próprias e manual para emissor parceiro.</p>
             </div>
             <div class="form-field--compact" id="valor-venda-final-wrapper">
                 <label class="form-label" for="{{ form.valor_venda_final.id_for_label }}">Valor final ao cliente (R$)</label>
@@ -297,8 +297,6 @@ const escalasVoltaData = {{ escalas_volta_json|safe }};
 const aeroportos = {{ aeroportos_json|safe }};
 const clienteProgramas = {{ cliente_programas_json|safe }};
 const contasAdmProgramas = {{ contas_adm_programas_json|safe }};
-const emissorParceiroProgramas = {{ emissor_parceiros_json|safe }};
-const programasParceiro = {{ programas_parceiros_json|safe }};
 
 const passageirosContainer = document.getElementById('passageiros-container');
 const clienteSelect = document.getElementById('id_cliente');
@@ -339,6 +337,9 @@ if (lucroField) {
 if (valorRefPontosField) {
     valorRefPontosField.readOnly = true;
 }
+if (custoParceiroField) {
+    custoParceiroField.readOnly = true;
+}
 
 function setVoltaVisibility() {
     if (!horarioVolta) return;
@@ -365,15 +366,7 @@ function getTipoEmissao() {
 
 function getProgramasDisponiveis() {
     const tipo = getTipoEmissao();
-    if (tipo === "parceiro") {
-        const emissorId = emissorParceiroSelect ? emissorParceiroSelect.value : null;
-        if (!emissorId || !emissorParceiroProgramas || !programasParceiro) {
-            return [];
-        }
-        const allowedIds = emissorParceiroProgramas[emissorId] || [];
-        return programasParceiro.filter((p) => allowedIds.includes(p.id));
-    }
-    if (tipo === "administrada") {
+    if (tipo === "administrada" || tipo === "parceiro") {
         const contaId = contaAdmSelect ? contaAdmSelect.value : null;
         return (contasAdmProgramas && contaId) ? (contasAdmProgramas[contaId] || []) : [];
     }
@@ -397,8 +390,8 @@ function updateProgramaInfo() {
         if (cpfUsadosInfo) {
             const usadosList = selected.cpfs_usados_list || [];
             cpfUsadosInfo.textContent = usadosList.length
-                ? `CPFs usados no programa: ${usadosList.join(", ")}`
-                : "CPFs usados no programa: nenhum";
+                ? `CPFs usados na conta: ${usadosList.join(", ")}`
+                : "CPFs usados na conta: nenhum";
         }
     } else if (programas.length) {
         programaInfo.textContent = "Nenhum programa disponível para o titular selecionado.";
@@ -436,6 +429,9 @@ function recalcValoresFinanceiros() {
     const valorMilheiro = tipo === "parceiro"
         ? parseFloat(custoParceiroField ? (custoParceiroField.value || 0) : 0)
         : (selected ? (selected.valor_medio || 0) : 0);
+    if (custoParceiroField && tipo !== "parceiro") {
+        custoParceiroField.value = valorMilheiro ? Number(valorMilheiro).toFixed(2) : "";
+    }
     const valorRefPontos = (pontos / 1000) * (valorMilheiro || 0);
     if (valorRefPontosField) {
         valorRefPontosField.value = valorRefPontos.toFixed(2);
@@ -452,15 +448,13 @@ function recalcValoresFinanceiros() {
 
 function updateLucro(custoTotal) {
     if (!lucroField) return;
-    if (getTipoEmissao() !== "parceiro") {
-        lucroField.value = "";
-        return;
-    }
     const custo = parseFloat(valorRefPontosField ? (valorRefPontosField.value || 0) : 0);
     const venda = parseFloat(vendaFinalField ? (vendaFinalField.value || 0) : 0);
     const custoBase = custoTotal !== undefined ? custoTotal : custo;
     if (custoBase || venda) {
         lucroField.value = (venda - custoBase).toFixed(2);
+    } else {
+        lucroField.value = "";
     }
 }
 
@@ -468,31 +462,25 @@ function toggleTitularFields() {
     const tipo = getTipoEmissao();
     if (clienteWrapper && contaAdmWrapper) {
         clienteWrapper.style.display = "block";
-        contaAdmWrapper.style.display = tipo === "administrada" ? "block" : "none";
+        contaAdmWrapper.style.display = (tipo === "administrada" || tipo === "parceiro") ? "block" : "none";
     }
     if (emissorParceiroWrapper) {
         emissorParceiroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
     }
     if (valorMilheiroParceiroWrapper) {
-        valorMilheiroParceiroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+        valorMilheiroParceiroWrapper.style.display = "block";
     }
     if (valorVendaFinalWrapper) {
-        valorVendaFinalWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+        valorVendaFinalWrapper.style.display = "block";
     }
     if (lucroWrapper) {
-        lucroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
+        lucroWrapper.style.display = "block";
     }
     if (tipo !== "parceiro" && emissorParceiroSelect) {
         emissorParceiroSelect.value = "";
     }
-    if (tipo !== "parceiro" && custoParceiroField) {
-        custoParceiroField.value = "";
-    }
-    if (tipo !== "parceiro" && vendaFinalField) {
-        vendaFinalField.value = "";
-    }
-    if (tipo !== "parceiro" && lucroField) {
-        lucroField.value = "";
+    if (custoParceiroField) {
+        custoParceiroField.readOnly = tipo !== "parceiro";
     }
     updateProgramaOptions();
 }
@@ -600,6 +588,7 @@ function renderPassengerForms() {
         }
     });
     updateCpfLimite();
+    updatePassaporteRequirements();
 }
 
 ['id_qtd_adultos','id_qtd_criancas','id_qtd_bebes'].forEach(id=>{
@@ -607,6 +596,16 @@ function renderPassengerForms() {
     if(el) el.addEventListener('input', renderPassengerForms);
 });
 renderPassengerForms();
+
+function updatePassaporteRequirements() {
+    passageirosContainer.querySelectorAll('.passageiro-fields').forEach((div) => {
+        const passaporteInput = div.querySelector('input[name$="-passaporte"]');
+        const validadeInput = div.querySelector('input[name$="-passaporte-validade"]');
+        if (!passaporteInput || !validadeInput) return;
+        const hasPassaporte = (passaporteInput.value || "").trim().length > 0;
+        validadeInput.required = hasPassaporte;
+    });
+}
 
 function normalizeCpf(value) {
     return (value || "").replace(/\D/g, "");
@@ -658,6 +657,9 @@ function updateCpfLimite() {
 passageirosContainer.addEventListener('input', (event) => {
     if (event.target && event.target.name && event.target.name.includes('-cpf')) {
         updateCpfLimite();
+    }
+    if (event.target && event.target.name && event.target.name.includes('-passaporte')) {
+        updatePassaporteRequirements();
     }
 });
 

--- a/gestao/templates/admin_custom/form_emissor_parceiro.html
+++ b/gestao/templates/admin_custom/form_emissor_parceiro.html
@@ -16,10 +16,6 @@
         {{ form.nome }}
     </div>
     <div class="form-group single">
-        <label class="form-label" for="{{ form.programas.id_for_label }}">Programas disponíveis</label>
-        {{ form.programas }}
-    </div>
-    <div class="form-group single">
         <label class="form-label" for="{{ form.ativo.id_for_label }}">Ativo</label>
         {{ form.ativo }}
     </div>

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -158,7 +158,7 @@ def programas_do_cliente(request, cliente_id):
         valor_pago = conta.valor_total_pago
         valor_medio_milheiro = conta.valor_medio_por_mil
         cpfs_usados = conta.cpfs_utilizados
-        cpfs_total = conta.programa.quantidade_cpfs_disponiveis
+        cpfs_total = conta.quantidade_cpfs_disponiveis
         cpfs_disponiveis = conta.cpfs_disponiveis
 
         lista_contas.append(

--- a/gestao/views/contas.py
+++ b/gestao/views/contas.py
@@ -193,7 +193,7 @@ def programas_da_conta_administrada(request, conta_id):
                 "valor_pago": c.valor_total_pago,
                 "valor_medio_milheiro": c.valor_medio_por_mil,
                 "cpfs_usados": c.cpfs_utilizados,
-                "cpfs_total": c.programa.quantidade_cpfs_disponiveis,
+                "cpfs_total": c.quantidade_cpfs_disponiveis,
                 "cpfs_disponiveis": c.cpfs_disponiveis,
             }
         )

--- a/gestao/views/emissores_parceiros.py
+++ b/gestao/views/emissores_parceiros.py
@@ -11,7 +11,7 @@ def admin_emissores_parceiros(request):
     if permission_denied := require_admin_or_operator(request):
         return permission_denied
     empresa = getattr(getattr(request.user, "cliente_gestao", None), "empresa", None)
-    emissores = EmissorParceiro.objects.all().prefetch_related("programas")
+    emissores = EmissorParceiro.objects.all()
     if empresa:
         emissores = emissores.filter(empresa=empresa)
     return render(
@@ -32,7 +32,6 @@ def criar_emissor_parceiro(request):
             emissor = form.save(commit=False)
             emissor.empresa = empresa
             emissor.save()
-            form.save_m2m()
             return redirect("admin_emissores_parceiros")
     else:
         form = EmissorParceiroForm()

--- a/painel_cliente/static/painel_cliente/css/base/variables.css
+++ b/painel_cliente/static/painel_cliente/css/base/variables.css
@@ -9,6 +9,8 @@
   --color-success: #2f855a;
   --color-danger: #e53e3e;
   --color-surface: #ffffff;
+  --color-surface-muted: #f9fafb;
+  --color-surface-active: #ebf4ff;
   --color-input-bg: #edf2f7;
   --color-input-border: #cbd5e0;
 
@@ -26,4 +28,22 @@
   --space-md: 16px;
   --space-lg: 20px;
   --space-xl: 30px;
+}
+
+body.dark-mode {
+  --color-bg: #0f172a;
+  --color-text: #e2e8f0;
+  --color-heading: #f8fafc;
+  --color-primary: #60a5fa;
+  --color-primary-dark: #3b82f6;
+  --color-muted: #94a3b8;
+  --color-border: #1f2937;
+  --color-surface: #111827;
+  --color-surface-muted: #1f2937;
+  --color-surface-active: #1d4ed8;
+  --color-input-bg: #1f2937;
+  --color-input-border: #374151;
+  --shadow-card: 0 10px 18px rgba(15, 23, 42, 0.4);
+  --shadow-table: 0 10px 16px rgba(15, 23, 42, 0.4);
+  --shadow-login: 0 2px 32px rgba(15, 23, 42, 0.4);
 }

--- a/painel_cliente/static/painel_cliente/css/components/cards.css
+++ b/painel_cliente/static/painel_cliente/css/components/cards.css
@@ -15,7 +15,7 @@
 .card-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-heading);
 }
 
 .card-content {

--- a/painel_cliente/static/painel_cliente/css/components/tables.css
+++ b/painel_cliente/static/painel_cliente/css/components/tables.css
@@ -16,7 +16,7 @@ td {
 }
 
 th {
-  background: #2d3748;
+  background: var(--color-primary-dark);
   color: var(--color-surface);
   font-weight: 600;
 }

--- a/painel_cliente/static/painel_cliente/css/layout/layout.css
+++ b/painel_cliente/static/painel_cliente/css/layout/layout.css
@@ -70,12 +70,12 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .nav-item:hover {
-  background: #f9fafb;
+  background: var(--color-surface-muted);
   color: var(--color-text);
 }
 
 .nav-item.is-active {
-  background: #ebf4ff;
+  background: var(--color-surface-active);
   color: var(--color-primary);
   border-right-color: var(--color-primary);
   font-weight: 600;
@@ -111,8 +111,19 @@ body.sidebar-open .sidebar-overlay {
 .app-header__title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #2d3748;
+  color: var(--color-heading);
   text-transform: capitalize;
+}
+
+.app-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-name {
+  color: var(--color-muted);
+  font-weight: 600;
 }
 
 .app-main {
@@ -135,7 +146,7 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .icon-button:hover {
-  background: #edf2f7;
+  background: var(--color-surface-muted);
 }
 
 .icon {

--- a/painel_cliente/static/painel_cliente/js/app.js
+++ b/painel_cliente/static/painel_cliente/js/app.js
@@ -1,5 +1,6 @@
 import { initLoginFocus } from "./modules/login.js";
 import { initTableEnhancements } from "./modules/tables.js";
+import { initThemeToggle } from "./modules/theme.js";
 
 const initSidebarToggle = () => {
   const sidebar = document.querySelector("[data-sidebar]");
@@ -44,4 +45,5 @@ document.addEventListener("DOMContentLoaded", () => {
   initLoginFocus();
   initTableEnhancements();
   initSidebarToggle();
+  initThemeToggle();
 });

--- a/painel_cliente/static/painel_cliente/js/modules/theme.js
+++ b/painel_cliente/static/painel_cliente/js/modules/theme.js
@@ -1,0 +1,32 @@
+const STORAGE_KEY = "darkMode";
+
+const applyTheme = (isDark) => {
+  document.body.classList.toggle("dark-mode", isDark);
+  const toggles = document.querySelectorAll("[data-theme-toggle]");
+  toggles.forEach((toggle) => {
+    toggle.textContent = isDark ? "☀️" : "🌙";
+    toggle.setAttribute("aria-pressed", isDark ? "true" : "false");
+    toggle.setAttribute(
+      "aria-label",
+      isDark ? "Desativar modo escuro" : "Ativar modo escuro"
+    );
+  });
+};
+
+export const initThemeToggle = () => {
+  const isDark = localStorage.getItem(STORAGE_KEY) === "enabled";
+  applyTheme(isDark);
+
+  const toggles = document.querySelectorAll("[data-theme-toggle]");
+  if (!toggles.length) {
+    return;
+  }
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener("click", () => {
+      const nextState = !document.body.classList.contains("dark-mode");
+      localStorage.setItem(STORAGE_KEY, nextState ? "enabled" : "disabled");
+      applyTheme(nextState);
+    });
+  });
+};

--- a/painel_cliente/templates/painel_cliente/base_painel.html
+++ b/painel_cliente/templates/painel_cliente/base_painel.html
@@ -78,9 +78,13 @@
                 </div>
                 <div class="app-header__actions">
                     {% if request.user.is_authenticated %}
+                        <span class="user-name">{{ request.user.get_full_name|default:request.user.username }}</span>
+                        <button class="icon-button" type="button" data-theme-toggle aria-label="Alternar modo escuro">🌙</button>
                         <form action="{% url 'logout' %}" method="post">{% csrf_token %}
                             <button class="btn btn--outline btn--sm" type="submit">Logout</button>
                         </form>
+                    {% else %}
+                        <button class="icon-button" type="button" data-theme-toggle aria-label="Alternar modo escuro">🌙</button>
                     {% endif %}
                 </div>
             </header>

--- a/painel_cliente/templates/painel_cliente/movimentacoes.html
+++ b/painel_cliente/templates/painel_cliente/movimentacoes.html
@@ -15,6 +15,7 @@
                     <th>Descrição</th>
                     <th>Pontos</th>
                     <th>Valor Pago</th>
+                    <th>CPFs consumidos</th>
                 </tr>
             </thead>
             <tbody>
@@ -32,10 +33,11 @@
                         {{ mov.pontos }}
                     </td>
                     <td>R$ {{ mov.valor_pago|floatformat:2 }}</td>
+                    <td>{% if mov.emissao_id %}{{ mov.cpfs_consumidos }}{% else %}—{% endif %}</td>
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="4" class="table-empty">Nenhuma movimentação encontrada.</td>
+                    <td colspan="5" class="table-empty">Nenhuma movimentação encontrada.</td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
### Motivation
- Padronizar o layout e comportamento do `sidebar`/`header` entre Gestão e Painel do Cliente para evitar duplicação e inconsistências.  
- Tornar o Dark Mode uma opção global e persistida para todo o sistema.  
- Corrigir a regra crítica de limite de CPF para que seja aplicada por `ContaFidelidade` e não por programa global.  
- Ajustar o fluxo de Emissor Parceiro e validações de documentos (passaporte/validade) para evitar inconsistências na emissão.

### Description
- Unifiquei HTML/CSS/JS do shell: ambos os templates usam atributos e markup compatível com `data-sidebar`, `data-sidebar-open`, `data-sidebar-close` e `data-sidebar-overlay`, e removi duplicações no admin; adicionei o script de tema compartilhado `painel_cliente/js/modules/theme.js` e inicialização em `painel_cliente/js/app.js`.  
- Implementei Dark Mode global usando toggle com `data-theme-toggle`, persistência em `localStorage` e variáveis CSS `body.dark-mode` (arquivos atualizados: CSS base e temas em `gestao/` e `painel_cliente/`).  
- Mudei a arquitetura do limite de CPFs para ser por conta: `gestao/services/cpf_limite.py` agora recebe `ContaFidelidade`, `gestao/models/conta_fidelidade.py` calcula `cpfs_utilizados`/`cpfs_disponiveis` filtrando por titular (cliente ou conta administrada), e `gestao/services/clientes_programas.py` foi adaptado para mapear CPFs por (tipo, titular, programa).  
- Atualizei validação e UI de emissão: `gestao/forms.py`, `gestao/views/emissoes.py` e `gestao/templates/admin_custom/form_emissao_passagem.html` validam e exibem consumo de CPFs por conta, bloqueiam salvamento quando excede o limite, e ajustam comportamento e campos para emissor parceiro (ex.: `EmissorParceiro` não carrega `programas` no formulário, exigência de escolher `conta_administrada` para emissor parceiro e cálculos de `lucro`/`valor_milheiro_parceiro`).  
- Várias melhorias de UX: containers full-width (`--page-max-width` removido), componentes padronizados (cards/tables cores via variáveis), coluna de CPFs consumidos em `movimentacoes` (tanto painel cliente quanto admin) e validação de validade do passaporte somente quando passaporte é informado (JS + template). 

### Testing
- Levantei o servidor de desenvolvimento com `python manage.py runserver` e confirmei que o servidor iniciou corretamente e capturei uma captura de tela da tela de login via Playwright (artefato gerado).  
- Não foram executados testes automatizados unitários no rollout; a execução do servidor exibiu um aviso de migrações pendentes (`1 unapplied migration(s)`).  
- Verifiquei manualmente, via inspeção de templates e scripts, que os novos toggles e atributos (`data-theme-toggle`, `data-sidebar-*`) foram incluídos nas bases de template compartilhadas.  
- Commits e alterações foram aplicados e validados localmente (commit realizado), porém recomenda-se rodar a suíte de testes e aplicar migrações antes de deploy em produção.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69547e173d948327bc2e31440eee3d1c)