### PR TITLE
Ajustar layout da Gestão para largura total e alinhar comportamento do sidebar

### DIFF
--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -13,6 +13,10 @@ body {
   display: block;
 }
 
+.app-shell [data-sidebar-overlay] {
+  display: block;
+}
+
 .fpp-container {
   width: 100%;
   max-width: none;
@@ -37,13 +41,8 @@ body {
 
 .fpp-sidebar,
 .app-shell .sidebar {
-  width: 256px;
+  width: var(--sidebar-width);
   flex-shrink: 0;
-  height: 100vh;
-  position: fixed;
-  top: 0;
-  left: 0;
-  transform: translateX(0);
 }
 
 .fpp-sidebar .sidebar-title,
@@ -72,8 +71,8 @@ body {
 }
 
 .app-shell__content {
-  margin-left: 256px;
-  width: calc(100% - 256px);
+  margin-left: 0;
+  width: 100%;
   transition: transform 0.3s ease;
 }
 
@@ -85,7 +84,7 @@ body {
 }
 
 .sidebar-header {
-  justify-content: flex-end;
+  justify-content: space-between;
 }
 
 .app-identity {
@@ -100,6 +99,7 @@ body {
   margin-left: 0;
   padding: 24px;
   background: #f8fafc;
+  width: 100%;
 }
 
 .page-header__titles {
@@ -118,25 +118,6 @@ body {
 @media (max-width: 768px) {
   .fpp-layout {
     flex-direction: column;
-  }
-
-  .fpp-sidebar,
-  .app-shell .sidebar {
-    width: 256px;
-    transform: translateX(-100%);
-  }
-
-  body.sidebar-open .app-shell .sidebar {
-    transform: translateX(0);
-  }
-
-  body.sidebar-open .app-shell__content {
-    transform: translateX(var(--sidebar-width));
-  }
-
-  .app-shell__content {
-    margin-left: 0;
-    width: 100%;
   }
 
   .app-main {

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{% static 'gestao/css/main.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
     <link rel="stylesheet" href="{% static 'painel_cliente/css/layout/layout.css' %}">
+    <link rel="stylesheet" href="{% static 'gestao/css/layout.css' %}">
 
     {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
### Motivation
- Unificar o comportamento e aparência da área de Gestão com o Painel do Cliente para evitar duplicação de markup e comportamento divergente.
- Garantir que o layout da Gestão ocupe 100% da viewport e que os containers não apliquem max-widths ou margins limitantes.
- Fazer com que o sidebar e o header reutilizem o mesmo HTML/JS compartilhado (mesmo script `painel_cliente/js/app.js`) e suportem o overlay/mobile corretamente.
- Corrigir problemas onde o sidebar abria sem exibir menus ou onde containers tinham larguras inconsistentes.

### Description
- Adicionada a importação do arquivo de sobrescrita de layout da Gestão em `gestao/templates/admin_custom/base_admin.html` com `gestao/css/layout.css` para aplicar overrides somente na Gestão.
- Atualizado `gestao/static/gestao/css/layout.css` para usar a variável `--sidebar-width`, remover margens/max-widths limitantes e forçar `width: 100%` em containers centrais (`.app-shell__content`, `.fpp-container`, `.page-shell`), tornando o layout full-width.
- Tornado visível o overlay do sidebar com a regra `.app-shell [data-sidebar-overlay] { display: block; }` e removidas transformações/movimentações redundantes na media query mobile para confiar no script compartilhado de toggle.
- Pequenos ajustes visuais: `sidebar-header` passa a `justify-content: space-between` e `app-main` recebe `width: 100%` para padronizar preenchimento e evitar encolhimentos inconsistentes.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955261a7d848327a5e7a0bc7fad9de7)