### PR TITLE
Emissões: separar cálculos por tipo (cliente/administrada/parceiro) e corrigir dashboard de parceiros

### DIFF
--- a/gestao/models/emissao_passagem.py
+++ b/gestao/models/emissao_passagem.py
@@ -82,13 +82,17 @@ class EmissaoPassagem(models.Model):
 
     def save(self, *args, **kwargs):
         self.qtd_passageiros = self.qtd_adultos + self.qtd_criancas + self.qtd_bebes
-        if self.valor_milheiro_parceiro is not None and self.valor_venda_final is not None:
+        if self.valor_milheiro_parceiro is not None:
             pontos = Decimal(self.pontos_utilizados or 0)
-            valor_milheiro = Decimal(self.valor_milheiro_parceiro)
-            custo_total = (pontos / Decimal("1000")) * valor_milheiro
-            self.lucro = Decimal(self.valor_venda_final) - custo_total
-        elif self.valor_venda_final is None:
-            self.lucro = None
+            valor_milheiro = Decimal(self.valor_milheiro_parceiro or 0)
+            custo_milhas = (pontos / Decimal("1000")) * valor_milheiro
+            custo_total = custo_milhas
+            if not self.emissor_parceiro_id:
+                custo_total += Decimal(self.valor_pago or 0)
+            if self.valor_venda_final is not None:
+                self.lucro = Decimal(self.valor_venda_final) - custo_total
+            elif self.lucro is None:
+                self.lucro = Decimal("0")
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/gestao/services/emissao_financeiro.py
+++ b/gestao/services/emissao_financeiro.py
@@ -15,12 +15,40 @@ def calcular_valor_referencia_pontos(pontos_utilizados: int, valor_medio_milheir
     return (pontos / Decimal("1000")) * valor_medio
 
 
-def calcular_economia(emissao: EmissaoPassagem, valor_referencia_pontos: Decimal) -> Decimal:
-    """Calcula a economia considerando dinheiro + custo real dos pontos."""
+def calcular_custo_milhas(pontos_utilizados: int, valor_milheiro: Decimal | float) -> Decimal:
+    """Retorna o custo das milhas baseado no valor do milheiro da emissão."""
+
+    pontos = Decimal(pontos_utilizados or 0)
+    valor = Decimal(valor_milheiro or 0)
+    return (pontos / Decimal("1000")) * valor
+
+
+def calcular_custo_total_emissao(
+    emissao: EmissaoPassagem, valor_milheiro: Decimal | float, incluir_taxas: bool = True
+) -> Decimal:
+    """Calcula o custo total da emissão, com opção de incluir taxas."""
+
+    custo_milhas = calcular_custo_milhas(emissao.pontos_utilizados or 0, valor_milheiro)
+    if incluir_taxas:
+        custo_milhas += Decimal(emissao.valor_pago or 0)
+    return custo_milhas
+
+
+def calcular_lucro_emissao(emissao: EmissaoPassagem, custo_base: Decimal | float) -> Decimal:
+    """Calcula o lucro da emissão considerando o custo base informado."""
+
+    if emissao.valor_venda_final in (None, ""):
+        return Decimal("0")
+    return Decimal(emissao.valor_venda_final or 0) - Decimal(custo_base or 0)
+
+
+def calcular_economia(emissao: EmissaoPassagem, custo_total: Decimal | float) -> Decimal:
+    """Calcula a economia obtida seguindo as regras de valor final e custo total."""
 
     valor_referencia = Decimal(emissao.valor_referencia or 0)
-    valor_pago = Decimal(emissao.valor_pago or 0)
-    return valor_referencia - (valor_pago + valor_referencia_pontos)
+    if emissao.valor_venda_final not in (None, ""):
+        return valor_referencia - Decimal(emissao.valor_venda_final or 0)
+    return Decimal(custo_total or 0)
 
 
 def registrar_movimentacao_pontos(

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -71,14 +71,43 @@
         <h2 class="section-title">Resumo rápido</h2>
       </div>
     </div>
+    {% if view_type == "parceiros" %}
+    <div class="stat-grid">
+      <div class="stat-card">
+        <p class="stat-label">✈️ Total de Emissões</p>
+        <p class="stat-value">{{ total_emissoes }}</p>
+        <p class="stat-meta">Emissões vinculadas ao emissor selecionado</p>
+      </div>
+      <div class="stat-card">
+        <p class="stat-label">🧾 Total de milhas emitidas</p>
+        <p class="stat-value">{{ parceiros.milhas }}</p>
+        <p class="stat-meta">Milhas usadas nas emissões do parceiro</p>
+      </div>
+      <div class="stat-card">
+        <p class="stat-label">💸 Valor pago ao parceiro</p>
+        <p class="stat-value">R$ {{ parceiros.valor_pago|floatformat:2 }}</p>
+        <p class="stat-meta">Somatório de milhas × valor do milheiro</p>
+      </div>
+      <div class="stat-card">
+        <p class="stat-label">💰 Lucro total</p>
+        <p class="stat-value">R$ {{ parceiros.lucro|floatformat:2 }}</p>
+        <p class="stat-meta">Lucro consolidado das emissões</p>
+      </div>
+      <div class="stat-card">
+        <p class="stat-label">📈 Valor médio do milheiro</p>
+        <p class="stat-value">R$ {{ parceiros.valor_medio_milheiro|floatformat:2 }}</p>
+        <p class="stat-meta">Média ponderada por milhas emitidas</p>
+      </div>
+    </div>
+    {% else %}
     <div class="stat-grid">
       <div class="stat-card">
         <p class="stat-label">
-          {% if view_type == "contas" %}🏢 Total de Contas{% elif view_type == "parceiros" %}🤝 Total de Emissores{% else %}👥 Total de Clientes{% endif %}
+          {% if view_type == "contas" %}🏢 Total de Contas{% else %}👥 Total de Clientes{% endif %}
         </p>
         <p class="stat-value">{{ total_titulares }}</p>
         <p class="stat-meta">
-          {% if view_type == "contas" %}Contas administradas ativas{% elif view_type == "parceiros" %}Emissores parceiros disponíveis{% else %}Base ativa de clientes acompanhados{% endif %}
+          {% if view_type == "contas" %}Contas administradas ativas{% else %}Base ativa de clientes acompanhados{% endif %}
         </p>
       </div>
       <div class="stat-card">
@@ -87,15 +116,12 @@
         <p class="stat-meta">Passagens emitidas em todos os programas</p>
       </div>
       <div class="stat-card">
-        <p class="stat-label">{% if view_type == "parceiros" %}💰 Lucro total{% else %}💰 Total Economizado{% endif %}</p>
-        <p class="stat-value">
-          {% if view_type == "parceiros" %}R$ {{ parceiros.lucro|floatformat:2 }}{% else %}R$ {{ total_economizado|floatformat:2 }}{% endif %}
-        </p>
-        <p class="stat-meta">
-          {% if view_type == "parceiros" %}Lucro consolidado das emissões{% else %}Economia acumulada em emissões e reservas{% endif %}
-        </p>
+        <p class="stat-label">💰 Total Economizado</p>
+        <p class="stat-value">R$ {{ total_economizado|floatformat:2 }}</p>
+        <p class="stat-meta">Economia acumulada em emissões e reservas</p>
       </div>
     </div>
+    {% endif %}
   </section>
 
   {% if view_type != "parceiros" %}
@@ -143,10 +169,17 @@
         <p class="stat-value">{{ emissoes.qtd }}</p>
         <p class="stat-meta">Quantidade total de emissões</p>
         <ul class="list-plain">
-          <li>Total de pontos usados: <strong>{{ emissoes.pontos }}</strong></li>
-          <li>Valor ref.: <strong>R$ {{ emissoes.valor_referencia|floatformat:2 }}</strong></li>
-          <li>Valor pago: <strong>R$ {{ emissoes.valor_pago|floatformat:2 }}</strong></li>
-          <li>{% if view_type == "parceiros" %}Vendas: <strong>R$ {{ parceiros.vendas|floatformat:2 }}</strong>{% else %}Economizado: <strong>R$ {{ emissoes.valor_economizado|floatformat:2 }}</strong>{% endif %}</li>
+          {% if view_type == "parceiros" %}
+            <li>Total de milhas emitidas: <strong>{{ parceiros.milhas }}</strong></li>
+            <li>Valor pago ao parceiro: <strong>R$ {{ parceiros.valor_pago|floatformat:2 }}</strong></li>
+            <li>Valor médio do milheiro: <strong>R$ {{ parceiros.valor_medio_milheiro|floatformat:2 }}</strong></li>
+            <li>Lucro: <strong>R$ {{ parceiros.lucro|floatformat:2 }}</strong></li>
+          {% else %}
+            <li>Total de pontos usados: <strong>{{ emissoes.pontos }}</strong></li>
+            <li>Valor ref.: <strong>R$ {{ emissoes.valor_referencia|floatformat:2 }}</strong></li>
+            <li>Valor pago: <strong>R$ {{ emissoes.valor_pago|floatformat:2 }}</strong></li>
+            <li>Economizado: <strong>R$ {{ emissoes.valor_economizado|floatformat:2 }}</strong></li>
+          {% endif %}
         </ul>
         <a class="card-link btn btn--ghost" href="{% url 'admin_emissoes' %}">Ver detalhes</a>
       </div>

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -54,7 +54,7 @@
             <div id="conta-adm-wrapper">
                 <label class="form-label" for="{{ form.conta_administrada.id_for_label }}">Conta administrada <span class="required-asterisk">*</span></label>
                 {{ form.conta_administrada }}
-                <p class="helper-text">Aparece quando a emissão usa conta administrada ou emissor parceiro.</p>
+                <p class="helper-text">Aparece quando a emissão usa conta administrada.</p>
             </div>
         </div>
         <div class="form-grid form-grid--3">
@@ -240,7 +240,7 @@
             <div class="form-field--compact" id="valor-milheiro-parceiro-wrapper">
                 <label class="form-label" for="{{ form.valor_milheiro_parceiro.id_for_label }}">Valor do milheiro (R$)</label>
                 {{ form.valor_milheiro_parceiro }}
-                <p class="helper-text">Preenchido automaticamente para contas próprias e manual para emissor parceiro.</p>
+                <p class="helper-text">Automático para conta do cliente e manual para conta administrada ou emissor parceiro.</p>
             </div>
             <div class="form-field--compact" id="valor-venda-final-wrapper">
                 <label class="form-label" for="{{ form.valor_venda_final.id_for_label }}">Valor final ao cliente (R$)</label>
@@ -297,6 +297,7 @@ const escalasVoltaData = {{ escalas_volta_json|safe }};
 const aeroportos = {{ aeroportos_json|safe }};
 const clienteProgramas = {{ cliente_programas_json|safe }};
 const contasAdmProgramas = {{ contas_adm_programas_json|safe }};
+const empresaProgramas = {{ empresa_programas_json|safe }};
 
 const passageirosContainer = document.getElementById('passageiros-container');
 const clienteSelect = document.getElementById('id_cliente');
@@ -338,7 +339,7 @@ if (valorRefPontosField) {
     valorRefPontosField.readOnly = true;
 }
 if (custoParceiroField) {
-    custoParceiroField.readOnly = true;
+    custoParceiroField.readOnly = getTipoEmissao() === "cliente";
 }
 
 function setVoltaVisibility() {
@@ -366,9 +367,12 @@ function getTipoEmissao() {
 
 function getProgramasDisponiveis() {
     const tipo = getTipoEmissao();
-    if (tipo === "administrada" || tipo === "parceiro") {
+    if (tipo === "administrada") {
         const contaId = contaAdmSelect ? contaAdmSelect.value : null;
         return (contasAdmProgramas && contaId) ? (contasAdmProgramas[contaId] || []) : [];
+    }
+    if (tipo === "parceiro") {
+        return empresaProgramas || [];
     }
     const clienteId = clienteSelect ? clienteSelect.value : null;
     return (clienteProgramas && clienteId) ? (clienteProgramas[clienteId] || []) : [];
@@ -426,43 +430,45 @@ function recalcValoresFinanceiros() {
     const selected = programas.find(p => String(p.id) === (programaSelect ? programaSelect.value : ""));
     const pontos = parseFloat(pontosField ? (pontosField.value || 0) : 0);
     const tipo = getTipoEmissao();
-    const valorMilheiro = tipo === "parceiro"
-        ? parseFloat(custoParceiroField ? (custoParceiroField.value || 0) : 0)
-        : (selected ? (selected.valor_medio || 0) : 0);
-    if (custoParceiroField && tipo !== "parceiro") {
+    const valorMilheiro = tipo === "cliente"
+        ? (selected ? (selected.valor_medio || 0) : 0)
+        : parseFloat(custoParceiroField ? (custoParceiroField.value || 0) : 0);
+    if (custoParceiroField && tipo === "cliente") {
         custoParceiroField.value = valorMilheiro ? Number(valorMilheiro).toFixed(2) : "";
     }
-    const valorRefPontos = (pontos / 1000) * (valorMilheiro || 0);
+    const custoMilhas = (pontos / 1000) * (valorMilheiro || 0);
     if (valorRefPontosField) {
-        valorRefPontosField.value = valorRefPontos.toFixed(2);
+        valorRefPontosField.value = custoMilhas.toFixed(2);
     }
     const valorRef = parseFloat(valorReferenciaField ? (valorReferenciaField.value || 0) : 0);
     const valorPago = parseFloat(valorPagoField ? (valorPagoField.value || 0) : 0);
-    const valorRefPts = parseFloat(valorRefPontosField ? (valorRefPontosField.value || 0) : 0);
+    const custoTotal = tipo === "parceiro" ? custoMilhas : (custoMilhas + valorPago);
+    const vendaRaw = vendaFinalField ? vendaFinalField.value : "";
+    const hasVenda = vendaRaw !== "" && vendaRaw !== null;
+    const valorVenda = parseFloat(vendaRaw || 0);
     if (economiaField) {
-        economiaField.value = (valorRef - (valorPago + valorRefPts)).toFixed(2);
+        economiaField.value = hasVenda
+            ? (valorRef - valorVenda).toFixed(2)
+            : custoTotal.toFixed(2);
     }
-    updateLucro(valorRefPontos);
+    if (lucroField) {
+        if (hasVenda) {
+            const baseLucro = tipo === "parceiro" ? custoMilhas : custoTotal;
+            lucroField.value = (valorVenda - baseLucro).toFixed(2);
+        } else if (custoTotal || valorRef) {
+            lucroField.value = "0.00";
+        } else {
+            lucroField.value = "";
+        }
+    }
     updateResumoVisual();
-}
-
-function updateLucro(custoTotal) {
-    if (!lucroField) return;
-    const custo = parseFloat(valorRefPontosField ? (valorRefPontosField.value || 0) : 0);
-    const venda = parseFloat(vendaFinalField ? (vendaFinalField.value || 0) : 0);
-    const custoBase = custoTotal !== undefined ? custoTotal : custo;
-    if (custoBase || venda) {
-        lucroField.value = (venda - custoBase).toFixed(2);
-    } else {
-        lucroField.value = "";
-    }
 }
 
 function toggleTitularFields() {
     const tipo = getTipoEmissao();
     if (clienteWrapper && contaAdmWrapper) {
         clienteWrapper.style.display = "block";
-        contaAdmWrapper.style.display = (tipo === "administrada" || tipo === "parceiro") ? "block" : "none";
+        contaAdmWrapper.style.display = tipo === "administrada" ? "block" : "none";
     }
     if (emissorParceiroWrapper) {
         emissorParceiroWrapper.style.display = tipo === "parceiro" ? "block" : "none";
@@ -480,7 +486,7 @@ function toggleTitularFields() {
         emissorParceiroSelect.value = "";
     }
     if (custoParceiroField) {
-        custoParceiroField.readOnly = tipo !== "parceiro";
+        custoParceiroField.readOnly = tipo === "cliente";
     }
     updateProgramaOptions();
 }
@@ -753,7 +759,7 @@ initEscalaSection('ida', escalasIdaData);
 initEscalaSection('volta', escalasVoltaData);
 toggleTitularFields();
 updateProgramaOptions();
-updateLucro();
+recalcValoresFinanceiros();
 
 function updateResumoVisual(){
     const origem = document.getElementById('id_aeroporto_partida');

--- a/gestao/views/cotacoes.py
+++ b/gestao/views/cotacoes.py
@@ -13,8 +13,9 @@ from gestao.services.clientes_programas import (
     build_contas_administradas_programas_map,
 )
 from gestao.services.emissao_financeiro import (
+    calcular_custo_milhas,
+    calcular_custo_total_emissao,
     calcular_economia,
-    calcular_valor_referencia_pontos,
     registrar_movimentacao_pontos,
 )
 from ..forms import (
@@ -249,12 +250,13 @@ def nova_cotacao_voo(request):
                             pontos_utilizados=cot.milhas,
                             detalhes=cot.observacoes,
                         )
-                        emissao.valor_referencia_pontos = calcular_valor_referencia_pontos(
+                        emissao.valor_referencia_pontos = calcular_custo_milhas(
                             emissao.pontos_utilizados, valor_medio_milheiro
                         )
-                        emissao.economia_obtida = calcular_economia(
-                            emissao, emissao.valor_referencia_pontos
+                        custo_total = calcular_custo_total_emissao(
+                            emissao, valor_medio_milheiro, incluir_taxas=True
                         )
+                        emissao.economia_obtida = calcular_economia(emissao, custo_total)
                         emissao.save()
                         for escala in cot.escalas.all():
                             Escala.objects.create(
@@ -373,12 +375,13 @@ def editar_cotacao_voo(request, cotacao_id):
                                 pontos_utilizados=cot.milhas,
                                 detalhes=cot.observacoes,
                             )
-                            emissao.valor_referencia_pontos = calcular_valor_referencia_pontos(
+                            emissao.valor_referencia_pontos = calcular_custo_milhas(
                                 emissao.pontos_utilizados, conta.valor_medio_por_mil
                             )
-                            emissao.economia_obtida = calcular_economia(
-                                emissao, emissao.valor_referencia_pontos
+                            custo_total = calcular_custo_total_emissao(
+                                emissao, conta.valor_medio_por_mil, incluir_taxas=True
                             )
+                            emissao.economia_obtida = calcular_economia(emissao, custo_total)
                             emissao.save()
                             for escala in cot.escalas.all():
                                 Escala.objects.create(


### PR DESCRIPTION
### Motivation
- Alinhar cálculos financeiros e regras de validação para os três tipos de emissão: `cliente`, `administrada` e `parceiro`, garantindo que o pagamento ao emissor parceiro considere apenas o custo das milhas e que taxas não sejam repassadas ao parceiro.
- Garantir que cada emissão contenha seu próprio valor do milheiro (quando aplicável) e que o frontend reflita apenas cálculos derivados do backend para evitar inconsistências.
- Corrigir cards e métricas do dashboard para que valores de emissores parceiros sejam calculados apenas a partir das emissões vinculadas ao parceiro e com média ponderada correta do milheiro.

### Description
- Adicionadas funções em `gestao/services/emissao_financeiro.py`: `calcular_custo_milhas`, `calcular_custo_total_emissao`, `calcular_lucro_emissao` e ajustada `calcular_economia` para aplicar as novas regras por emissão.
- Ajustes no modelo `EmissaoPassagem.save` para computar `lucro` considerando se a emissão é de parceiro (taxas excluídas do pagamento ao parceiro) e manter compatibilidade com emissões antigas.
- Alterações no formulário `EmissaoPassagemForm` (`gestao/forms.py`) para validações específicas por tipo, seleção de programas para `parceiro` baseada na empresa, e exigência/sem exigência de `conta_administrada` conforme o tipo.
- Backend e frontend sincronizados: atualizações em `gestao/views/emissoes.py`, `gestao/views/cotacoes.py`, `gestao/services/clientes_programas.py`, templates (`form_emissao_passagem.html`, `dashboard.html`) e JS para aplicar os novos cálculos, expor `empresa_programas_json` ao formulário e evitar registrar movimentações de pontos para emissões de parceiros.

### Testing
- Nenhum teste automatizado foi executado durante esta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955324fcb4c83279e9d3b3053989497)