### PR TITLE
Unify Gestão admin layout with painel_cliente styles and fix mobile sidebar/header/button behavior

### DIFF
--- a/gestao/static/gestao/css/painel.css
+++ b/gestao/static/gestao/css/painel.css
@@ -602,35 +602,6 @@ body.dark-mode .btn-delete {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.mobile-header {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 50px;
-  background: linear-gradient(180deg, #2c5aa0 0%, #1e3f66 100%);
-  color: #ffffff;
-  padding: 8px 12px;
-  z-index: 999;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.mobile-header h1 {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.mobile-header .menu-toggle {
-  background: transparent;
-  border: none;
-  color: #ffffff;
-  font-size: 20px;
-  cursor: pointer;
-  padding: 8px 12px;
-}
-
 /* ========== RESPONSIVIDADE - TABLET (até 1024px) ========== */
 @media (max-width: 1024px) {
   .sidebar {
@@ -657,36 +628,6 @@ body.dark-mode .btn-delete {
 
 /* ========== RESPONSIVIDADE - MOBILE (até 768px) ========== */
 @media (max-width: 768px) {
-  .mobile-header {
-    display: flex;
-  }
-
-  .sidebar {
-    width: 100%;
-    height: auto;
-    position: fixed;
-    top: 50px;
-    left: 0;
-    right: 0;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.3s ease;
-    z-index: 998;
-    padding: 0;
-  }
-
-  .sidebar.active {
-    max-height: 500px;
-    padding: 10px 0;
-    overflow-y: auto;
-  }
-
-  .sidebar a {
-    padding: 7px 14px;
-    font-size: 11px;
-    margin: 1px 0;
-  }
-
   main, .main-content {
     margin-left: 0;
     padding: 60px 10px 10px;

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -7,11 +7,10 @@
     <title>{% block title %}Administração{% endblock %} - Gestão de Pontos</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="{% static 'gestao/admin_custom.css' %}">
-    <link rel="stylesheet" href="{% static 'gestao/css/main.css' %}">
-    <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
+    <link rel="stylesheet" href="{% static 'gestao/css/base/variables.css' %}">
     <link rel="stylesheet" href="{% static 'painel_cliente/css/layout/layout.css' %}">
-    <link rel="stylesheet" href="{% static 'gestao/css/layout.css' %}">
+    <link rel="stylesheet" href="{% static 'painel_cliente/css/components/buttons.css' %}">
+    <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
 
     {% block extra_head %}{% endblock %}
 </head>

--- a/painel_cliente/static/painel_cliente/css/layout/layout.css
+++ b/painel_cliente/static/painel_cliente/css/layout/layout.css
@@ -132,6 +132,13 @@ body.sidebar-open .sidebar-overlay {
   padding: 24px;
 }
 
+.app-shell .btn,
+.app-shell button {
+  width: auto;
+  display: inline-flex;
+  white-space: nowrap;
+}
+
 .icon-button {
   width: 32px;
   height: 32px;
@@ -216,6 +223,22 @@ body.sidebar-open .sidebar-overlay {
 }
 
 @media (max-width: 768px) {
+  .app-header {
+    padding: 10px 16px;
+    height: 60px;
+  }
+
+  .app-header__title {
+    font-size: 1.1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .user-name {
+    display: none;
+  }
+
   .painel-cards.programas-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -229,6 +252,12 @@ body.sidebar-open .sidebar-overlay {
 @media (max-width: 640px) {
   .painel-cards.programas-grid {
     grid-template-columns: 1fr;
+  }
+
+  .fpp-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
   }
 
   .app-main {


### PR DESCRIPTION
### Motivation
- Unify the Gestão admin layout to the stable `painel_cliente` patterns so the sidebar, header and buttons behave consistently on mobile.
- Fix CSS conflicts that caused the Sidebar to open blank on mobile by removing legacy mobile-specific rules and centralizing layout styles.
- Improve header and title sizing on narrow viewports to prevent overflow and layout breakage.
- Prevent buttons from stretching to full width on non-form contexts so action controls keep proportional sizing.

### Description
- Updated `gestao/templates/admin_custom/base_admin.html` to simplify CSS includes and load `gestao/css/base/variables.css`, `painel_cliente/css/layout/layout.css`, `painel_cliente/css/components/buttons.css` and `gestao/formulario_base_gestao.css` in a consistent order.
- Added button sizing rules and responsive header/title rules to `painel_cliente/static/painel_cliente/css/layout/layout.css`, including ` .app-shell .btn, .app-shell button { ... }`, mobile `.app-header` sizing, `.app-header__title` truncation, and hiding `.user-name` under `@media (max-width: 768px)`.
- Added a compact action-grid for small viewports in `layout.css` via `.fpp-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }` under `@media (max-width: 640px)`.
- Removed legacy mobile accordion/sidebar rules from `gestao/static/gestao/css/painel.css` (mobile header and `.sidebar.active` accordion rules) to avoid conflicts with the shared layout and fix z-index/display issues.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955368eef9483279f89d8aeaf44d1e9)