### PR TITLE
Padroniza visual do Admin — inputs, botões, filtros e grids

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description" content="Login - NCFly Sistema de Gestão de Voos e Programas de Fidelidade" />
   <title>Login - NCFly</title>
-  <link rel="stylesheet" href="{% static 'gestao/css/main.css' %}">
+  <link rel="stylesheet" href="{% static 'gestao/css/login.css' %}">
 </head>
 <body class="login-page">
   <div class="login-container">

--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -68,7 +68,8 @@ body.dark-mode {
 .app-layout .sidebar {
   width: 240px;
   flex-shrink: 0;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   position: sticky;
   top: 0;
   overflow-y: auto;
@@ -192,8 +193,8 @@ a:hover {
 
 .page-title {
   margin: 0;
-  font-size: 1.8rem;
-  font-weight: 800;
+  font-size: 1.1rem;
+  font-weight: 600;
   color: var(--heading);
 }
 
@@ -216,7 +217,7 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1.25rem 1.5rem;
+  padding: 16px;
   margin-bottom: 1.875rem;
 }
 
@@ -230,23 +231,25 @@ a:hover {
 
 .section-title {
   margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--heading);
 }
 
 .section-subtitle {
   margin: 0.35rem 0 0;
   color: var(--muted);
+  font-size: 12px;
 }
 
 .btn {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.65rem 1rem;
-  min-height: 40px;
-  border-radius: 12px;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-size: 12px;
   font-weight: 700;
   border: 1px solid transparent;
   background: transparent;
@@ -284,8 +287,10 @@ a:hover {
 }
 
 .btn-link {
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-size: 12px;
   color: var(--primary);
 }
 
@@ -355,6 +360,10 @@ a:hover {
   min-width: 1100px;
 }
 
+.data-table--wide {
+  min-width: 1400px;
+}
+
 .data-table th,
 .data-table td {
   padding: 0.85rem 0.75rem;
@@ -421,6 +430,12 @@ a:hover {
   gap: 0.75rem;
 }
 
+.filter-grid {
+  display: grid;
+  grid-template-columns: 160px 160px 200px 180px;
+  gap: 12px;
+}
+
 .filter-actions {
   display: flex;
   gap: 0.75rem;
@@ -442,6 +457,11 @@ a:hover {
 .form-label {
   font-weight: 700;
   color: var(--heading);
+  font-size: 11px;
+}
+
+label {
+  font-size: 11px;
 }
 
 input[type="text"],
@@ -453,11 +473,21 @@ select,
 textarea {
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 0.7rem 0.9rem;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
   background: #f8fafc;
   color: var(--heading);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="password"],
+input[type="date"],
+input[type="datetime-local"],
+select {
+  height: 36px;
 }
 
 input:focus,
@@ -469,8 +499,12 @@ textarea:focus {
 }
 
 textarea {
-  min-height: 120px;
+  min-height: 96px;
   resize: vertical;
+}
+
+.helper-text {
+  font-size: 12px;
 }
 
 .form-actions {
@@ -482,8 +516,8 @@ textarea {
 }
 
 .form-title {
-  font-size: 1.5rem;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   margin-bottom: 0.25rem;
 }
 
@@ -614,7 +648,8 @@ textarea {
 
 .app-shell {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   background: var(--shell-bg);
   overflow: hidden;
 }
@@ -624,7 +659,8 @@ textarea {
   top: 0;
   left: 0;
   width: var(--sidebar-width);
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   background: var(--shell-surface);
   box-shadow: 6px 0 18px rgba(0, 0, 0, 0.08);
   transform: translateX(-100%);
@@ -821,11 +857,11 @@ body.sidebar-open .sidebar-overlay {
   align-items: center;
   justify-content: center;
   height: 36px;
-  padding: 0 16px;
-  border-radius: 8px;
+  padding: 0 14px;
+  border-radius: 6px;
   border: 1px solid transparent;
-  font-size: 0.875rem;
-  font-weight: 500;
+  font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
   background: var(--shell-primary);
@@ -850,14 +886,15 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .btn--sm {
-  height: 32px;
-  padding: 0 12px;
-  font-size: 0.8125rem;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
 }
 
 .btn--lg {
-  height: 40px;
-  padding: 0 24px;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
 }
 
 .btn--icon {
@@ -896,5 +933,11 @@ body.sidebar-open .sidebar-overlay {
 @media (max-width: 640px) {
   .app-main {
     padding: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .filter-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -45,6 +45,8 @@ body {
   max-width: none;
   margin: 0;
   padding: 0;
+  min-height: 100vh;
+  height: auto;
 }
 
 .fpp-layout,
@@ -274,20 +276,21 @@ body.sidebar-open .app-shell .sidebar {
 .app-shell button,
 .app-shell input[type="submit"] {
   height: 36px;
-  padding: 0 16px;
-  border-radius: 8px;
-  font-size: 0.875rem;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-size: 12px;
 }
 
 .app-shell .btn--sm {
-  height: 32px;
-  padding: 0 12px;
-  font-size: 0.8125rem;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
 }
 
 .app-shell .btn--lg {
-  height: 40px;
-  padding: 0 24px;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
 }
 
 .page-header__titles {

--- a/gestao/static/gestao/css/main.css
+++ b/gestao/static/gestao/css/main.css
@@ -1,7 +1,0 @@
-@import url("./base/reset.css");
-@import url("./base/variables.css");
-@import url("./base/typography.css");
-@import url("./utilities/utilities.css");
-@import url("./painel.css");
-@import url("./admin-theme.css");
-@import url("./login.css");

--- a/gestao/static/gestao/formulario_base_gestao.css
+++ b/gestao/static/gestao/formulario_base_gestao.css
@@ -14,20 +14,21 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
-  padding: 1.75rem;
+  padding: 16px;
   display: grid;
   gap: 1.25rem;
 }
 
 .form-title {
-  font-size: 1.35rem;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--heading);
   margin-bottom: 0.35rem;
 }
 
 .form-subtitle {
   color: var(--muted);
+  font-size: 12px;
   margin: 0 0 0.5rem;
 }
 
@@ -41,7 +42,7 @@
   background: #fdfdff;
   border: 1px solid var(--border);
   border-radius: 14px;
-  padding: 1.25rem 1.35rem;
+  padding: 16px;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
@@ -57,19 +58,20 @@
 }
 
 .section-card__title {
-  font-size: 1.05rem;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--heading);
 }
 
 .section-card__description {
   color: var(--muted);
+  font-size: 12px;
   margin-top: 0.25rem;
 }
 
 .section-title {
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--heading);
   margin-top: 0.5rem;
 }
@@ -78,16 +80,16 @@
 .form-group,
 .section-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: 1fr;
+  gap: 12px;
+  grid-template-columns: 180px 180px 200px;
 }
 
 .form-grid--2 {
-  grid-template-columns: 1fr;
+  grid-template-columns: 180px 200px;
 }
 
 .form-grid--3 {
-  grid-template-columns: 1fr;
+  grid-template-columns: 180px 180px 200px;
 }
 
 .form-group.single,
@@ -95,10 +97,17 @@
   grid-template-columns: 1fr;
 }
 
+.form-grid--dates {
+  display: grid;
+  grid-template-columns: 220px 160px;
+  gap: 12px;
+}
+
 .form-label {
   display: block;
   font-weight: 700;
   color: var(--heading);
+  font-size: 11px;
   margin-bottom: 0.35rem;
 }
 
@@ -112,8 +121,9 @@ select,
 textarea {
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 0.75rem 0.9rem;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
   background: #f8fafc;
   color: var(--heading);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -126,11 +136,11 @@ input[type="date"],
 input[type="datetime-local"],
 input[type="time"],
 select {
-  min-height: 44px;
+  height: 36px;
 }
 
 textarea {
-  min-height: 120px;
+  min-height: 96px;
   resize: vertical;
 }
 
@@ -147,7 +157,7 @@ textarea:focus {
   justify-content: flex-end;
   gap: 0.75rem;
   flex-wrap: wrap;
-  padding: 1rem 0 0;
+  padding: 12px 0 0;
   border-top: 1px solid var(--border);
   position: sticky;
   bottom: 0;
@@ -158,10 +168,12 @@ textarea:focus {
 .btn-primary {
   background: linear-gradient(135deg, var(--primary), var(--primary-strong));
   color: #ffffff;
-  font-weight: 700;
+  font-weight: 600;
   border: none;
-  border-radius: 12px;
-  padding: 0.8rem 1.35rem;
+  border-radius: 6px;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
   cursor: pointer;
   transition: filter 0.2s ease;
 }
@@ -211,10 +223,10 @@ textarea:focus {
   font-size: 0.9rem;
 }
 
-.scale-grid {
+.scale-panels {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
 }
 
 .scale-list {
@@ -223,13 +235,14 @@ textarea:focus {
   gap: 0.75rem;
 }
 
-.scale-row {
+.scale-row,
+.scale-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
-  gap: 0.75rem;
-  align-items: end;
-  padding: 0.75rem;
-  border-radius: 12px;
+  grid-template-columns: 160px 180px 120px 36px;
+  gap: 10px;
+  align-items: center;
+  padding: 8px;
+  border-radius: 10px;
   border: 1px dashed var(--border);
   background: #ffffff;
 }
@@ -243,9 +256,9 @@ textarea:focus {
 .scale-remove {
   border: 1px solid var(--border);
   background: #ffffff;
-  border-radius: 10px;
-  height: 44px;
-  width: 44px;
+  border-radius: 6px;
+  height: 36px;
+  width: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -292,7 +305,7 @@ textarea:focus {
 
 .helper-text {
   color: var(--muted);
-  font-size: 0.95rem;
+  font-size: 12px;
 }
 
 .section-divider {
@@ -352,27 +365,18 @@ textarea:focus {
   }
 }
 
-@media (min-width: 768px) {
-  .form-grid--2,
-  .section-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .form-grid--3,
-  .form-group {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .form-grid--3,
-  .form-group {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 768px) {
-  .scale-row {
+  .form-grid,
+  .form-grid--2,
+  .form-grid--3,
+  .form-group,
+  .section-grid,
+  .form-grid--dates {
+    grid-template-columns: 1fr;
+  }
+
+  .scale-row,
+  .scale-grid {
     grid-template-columns: 1fr;
   }
 

--- a/gestao/templates/admin_custom/aeroportos.html
+++ b/gestao/templates/admin_custom/aeroportos.html
@@ -20,7 +20,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="busca">Sigla ou nome</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -8,10 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="{% static 'gestao/css/base/variables.css' %}">
-    <link rel="stylesheet" href="{% static 'gestao/css/main.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/css/layout.css' %}">
     <link rel="stylesheet" href="{% static 'painel_cliente/css/components/buttons.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
+    <link rel="stylesheet" href="{% static 'gestao/css/admin-theme.css' %}">
 
     {% block extra_head %}{% endblock %}
 </head>

--- a/gestao/templates/admin_custom/clientes.html
+++ b/gestao/templates/admin_custom/clientes.html
@@ -18,8 +18,8 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 md:items-end">
-                <div class="form-field md:col-span-2 lg:col-span-3">
+            <form method="get" class="filter-grid">
+                <div class="form-field">
                     <label class="form-label" for="busca">Nome ou usuário</label>
                     <input
                         type="text"
@@ -29,9 +29,9 @@
                         placeholder="Buscar..."
                     />
                 </div>
-                <div class="form-actions flex gap-2 md:justify-end">
-                    <button type="submit" class="btn flex-1 md:flex-none">Buscar</button>
-                    <a href="{% url 'admin_clientes' %}" class="btn btn--ghost flex-1 md:flex-none">Limpar</a>
+                <div class="form-actions">
+                    <button type="submit" class="btn">Buscar</button>
+                    <a href="{% url 'admin_clientes' %}" class="btn btn--ghost">Limpar</a>
                 </div>
             </form>
         </div>

--- a/gestao/templates/admin_custom/companhias.html
+++ b/gestao/templates/admin_custom/companhias.html
@@ -18,7 +18,7 @@
       <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
     </div>
     <div class="filter-body is-open" data-filter-panel>
-      <form method="get" class="form-grid">
+      <form method="get" class="filter-grid">
         <div class="form-field">
           <label class="form-label" for="busca">Nome ou site</label>
           <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />

--- a/gestao/templates/admin_custom/contas.html
+++ b/gestao/templates/admin_custom/contas.html
@@ -17,14 +17,14 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 md:items-end">
-                <div class="form-field md:col-span-2 lg:col-span-3">
+            <form method="get" class="filter-grid">
+                <div class="form-field">
                     <label class="form-label" for="busca">Usuário ou programa</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar usuário ou programa..." />
                 </div>
-                <div class="form-actions flex gap-2 md:justify-end">
-                    <button type="submit" class="btn flex-1 md:flex-none">Buscar</button>
-                    <a href="{% url 'admin_contas' %}" class="btn btn--ghost flex-1 md:flex-none">Limpar</a>
+                <div class="form-actions">
+                    <button type="submit" class="btn">Buscar</button>
+                    <a href="{% url 'admin_contas' %}" class="btn btn--ghost">Limpar</a>
                 </div>
             </form>
         </div>

--- a/gestao/templates/admin_custom/contas_administradas.html
+++ b/gestao/templates/admin_custom/contas_administradas.html
@@ -18,14 +18,14 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 md:items-end">
-                <div class="form-field md:col-span-2 lg:col-span-3">
+            <form method="get" class="filter-grid">
+                <div class="form-field">
                     <label class="form-label" for="busca">Conta ou programa</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar conta ou programa..." />
                 </div>
-                <div class="form-actions flex gap-2 md:justify-end">
-                    <button type="submit" class="btn flex-1 md:flex-none">Buscar</button>
-                    <a href="{% url 'admin_contas_administradas' %}" class="btn btn--ghost flex-1 md:flex-none">Limpar</a>
+                <div class="form-actions">
+                    <button type="submit" class="btn">Buscar</button>
+                    <a href="{% url 'admin_contas_administradas' %}" class="btn btn--ghost">Limpar</a>
                 </div>
             </form>
         </div>

--- a/gestao/templates/admin_custom/cotacoes.html
+++ b/gestao/templates/admin_custom/cotacoes.html
@@ -43,7 +43,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="busca">Programa</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar programa..." />

--- a/gestao/templates/admin_custom/cotacoes_voo.html
+++ b/gestao/templates/admin_custom/cotacoes_voo.html
@@ -17,7 +17,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="busca">Origem, destino ou cliente</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -21,7 +21,7 @@
       <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
     </div>
     <div class="filter-body is-open" data-filter-panel>
-      <div class="form-grid">
+      <div class="filter-grid">
         <div class="form-field">
           <label class="form-label" for="viewSelect">Tipo de visão</label>
           <select id="viewSelect">

--- a/gestao/templates/admin_custom/emissoes.html
+++ b/gestao/templates/admin_custom/emissoes.html
@@ -19,7 +19,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="cliente">Cliente</label>
                     <select name="cliente" id="cliente">
@@ -69,7 +69,7 @@
             </div>
         </div>
         <div class="table-wrapper">
-            <table class="data-table">
+            <table class="data-table data-table--wide">
                 <thead>
                     <tr>
                         <th>Cliente</th>

--- a/gestao/templates/admin_custom/form_cotacao.html
+++ b/gestao/templates/admin_custom/form_cotacao.html
@@ -88,7 +88,7 @@
                 {{ form.companhia_aerea }}
             </div>
         </div>
-        <div class="form-grid form-grid--3">
+        <div class="form-grid form-grid--dates">
             <div>
                 <label class="form-label" for="{{ form.data_ida.id_for_label }}">Data e horário da ida <span class="required-asterisk">*</span></label>
                 {{ form.data_ida }}
@@ -104,7 +104,7 @@
             <p class="helper-text">Ative para informar o retorno.</p>
         </div>
         <div id="horario-volta" class="collapse-section">
-            <div class="form-grid form-grid--3">
+            <div class="form-grid form-grid--dates">
                 <div>
                     <label class="form-label" for="{{ form.data_volta.id_for_label }}">Data e horário da volta</label>
                     {{ form.data_volta }}
@@ -142,7 +142,7 @@
                 <p class="section-card__description">Ative somente quando houver conexões na ida ou na volta.</p>
             </div>
         </div>
-        <div class="scale-grid">
+        <div class="scale-panels">
             <div class="scale-card">
                 <div class="section-title">Escalas do voo de ida</div>
                 <div class="toggle-row">

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -96,7 +96,7 @@
                 {{ form.companhia_aerea }}
             </div>
         </div>
-        <div class="form-grid form-grid--3">
+        <div class="form-grid form-grid--dates">
             <div>
                 <label class="form-label" for="{{ form.data_ida.id_for_label }}">Data e horário da ida <span class="required-asterisk">*</span></label>
                 {{ form.data_ida }}
@@ -133,7 +133,7 @@
                 <p class="section-card__description">Informe o retorno apenas quando houver volta.</p>
             </div>
         </div>
-        <div class="form-grid form-grid--3">
+        <div class="form-grid form-grid--dates">
             <div>
                 <label class="form-label" for="{{ form.data_volta.id_for_label }}">Data e horário da volta</label>
                 {{ form.data_volta }}
@@ -691,7 +691,7 @@ function initEscalaSection(tipo, data){
         container.innerHTML='';
         for(let i=0;i<qtd;i++){
             const div = document.createElement('div');
-            div.className = 'scale-row escala-fields';
+            div.className = 'scale-row scale-grid escala-fields';
             div.dataset.index = i;
             let options = '<option value=""></option>';
             aeroportos.forEach(a=>{

--- a/gestao/templates/admin_custom/hoteis.html
+++ b/gestao/templates/admin_custom/hoteis.html
@@ -17,7 +17,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="busca">Cliente ou hotel</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />

--- a/gestao/templates/admin_custom/programas.html
+++ b/gestao/templates/admin_custom/programas.html
@@ -20,7 +20,7 @@
             <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
         </div>
         <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="form-grid">
+            <form method="get" class="filter-grid">
                 <div class="form-field">
                     <label class="form-label" for="busca">Nome ou base</label>
                     <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />


### PR DESCRIPTION
### Motivation
- Padronizar a aparência do Admin para corrigir campos muito altos, botões desproporcionais e tipografia inconsistente.
- Controlar largura de filtros e evitar que inputs/usem `width: 100%` indiscriminadamente para layouts mais compactos e legíveis.
- Tornar a tela de "Nova Emissão" mais densa e organizada com grids fixos e escalas menores.
- Eliminar conflitos e CSS duplicado garantindo que `admin-theme.css` prevaleça sobre arquivos legacy como `main.css`.

### Description
- Ajustes globais de estilo em `gestao/static/gestao/css/admin-theme.css` para normalizar inputs/selects e botões (altura `36px`, `padding: 6px 10px`, `border-radius: 6px`, `font-size: 12px`) e padronizar tipografia (`label`, `.section-title`, `.helper-text`).
- Introduzido o grid de filtros `filter-grid` com `grid-template-columns: 160px 160px 200px 180px` e media query para mobile, adicionado `data-table--wide` (min-width: 1400px) e ajustado comportamento de altura de shell (`min-height: 100vh`) em `admin-theme.css` e `layout.css`.
- Reformulado formulários em `gestao/static/gestao/formulario_base_gestao.css` para usar grids fixos (`.form-grid`, `.form-grid--dates`), compactar cards/paddings, reduzir alturas de `textarea` e padronizar componentes de escala (`.scale-grid`, `.scale-row`, `.scale-remove`).
- Removido `gestao/static/gestao/css/main.css`, atualizado `gestao/templates/admin_custom/base_admin.html` para incluir `admin-theme.css`, alteradas várias views/templates para usar `filter-grid`, aplicado `data-table--wide` em listagens largas e ajustadas marcações de escalas e botões; login agora referencia `login.css`.

### Testing
- Automated tests: none executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956cb36cd6c83279cb90eaf273d80bb)