### PR TITLE
Ajustar base do layout admin para ocupar viewport

### DIFF
--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -15,6 +15,13 @@
   --page-max-width: 100%;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+}
+
 body {
   background: var(--bg);
   color: var(--heading);
@@ -149,6 +156,9 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  min-height: 100vh;
+  height: auto;
+  overflow-x: hidden;
 }
 
 .topbar {
@@ -595,7 +605,8 @@ textarea {
     position: fixed;
     left: 0;
     top: 0;
-    height: 100vh;
+    min-height: 100vh;
+    height: 100%;
     width: 260px;
     transform: translateX(-100%);
     z-index: 40;
@@ -650,8 +661,10 @@ textarea {
   display: flex;
   min-height: 100vh;
   height: auto;
+  width: 100%;
   background: var(--shell-bg);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: visible;
 }
 
 .sidebar {
@@ -773,7 +786,10 @@ body.sidebar-open .sidebar-overlay {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  min-height: 100vh;
+  height: auto;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .app-header {
@@ -811,9 +827,11 @@ body.sidebar-open .sidebar-overlay {
 
 .app-main {
   flex: 1;
-  overflow: auto;
-  padding: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 24px;
   background: var(--shell-bg);
+  width: 100%;
 }
 
 .page-header {
@@ -932,11 +950,21 @@ body.sidebar-open .sidebar-overlay {
 
 @media (max-width: 640px) {
   .app-main {
-    padding: 0;
+    padding: 20px;
   }
 }
 
 @media (max-width: 768px) {
+  .app-shell,
+  .app-shell__content,
+  .page-shell,
+  .page-container,
+  .fpp-container {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
   .filter-grid {
     grid-template-columns: 1fr;
   }

--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -1,6 +1,8 @@
 html,
 body {
+  width: 100%;
   height: 100%;
+  overflow-x: hidden;
 }
 
 :root {
@@ -25,7 +27,6 @@ body {
   margin: 0;
   min-height: 100%;
   display: block;
-  overflow-x: hidden;
 }
 
 .app-shell [data-sidebar-overlay] {
@@ -47,6 +48,7 @@ body {
   padding: 0;
   min-height: 100vh;
   height: auto;
+  overflow-x: hidden;
 }
 
 .fpp-layout,
@@ -57,6 +59,7 @@ body {
   width: 100%;
   background: var(--color-bg);
   overflow-x: hidden;
+  overflow-y: visible;
 }
 
 .fpp-sidebar,
@@ -166,6 +169,7 @@ body.sidebar-open .app-shell .sidebar {
   min-height: 100vh;
   height: auto;
   overflow-x: hidden;
+  width: 100%;
 }
 
 .app-shell__content {
@@ -232,6 +236,7 @@ body.sidebar-open .app-shell .sidebar {
 .app-main {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   margin-left: 0;
   padding: 24px;
   background: var(--color-bg);
@@ -307,6 +312,16 @@ body.sidebar-open .app-shell .sidebar {
 }
 
 @media (max-width: 768px) {
+  .app-shell,
+  .app-shell__content,
+  .page-shell,
+  .fpp-container,
+  .page-container {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
   .fpp-layout {
     flex-direction: column;
   }


### PR DESCRIPTION
### Motivation
- Corrigir comportamento inconsistente de layout que fazia algumas páginas não ocuparem 100% da viewport e geravam scroll horizontal indesejado no desktop e mobile.
- Aplicar uma solução global no layout raiz para garantir comportamento consistente entre rotas sem correções específicas por página.

### Description
- Atualizei `gestao/static/gestao/css/layout.css` e `gestao/static/gestao/css/admin-theme.css` adicionando regras globais de largura/altura e controle de overflow no nível raiz.
- Adicionei `html, body { width: 100%; height: 100%; overflow-x: hidden; }` e normalizei containers raiz como `.app-shell`, `.page-shell`, `.app-shell__content`, `.app-main`, ` .fpp-container` e `.page-container` para `width: 100%`, `min-height: 100vh` e `overflow-x: hidden` principalmente via media queries para mobile.
- Ajustei o comportamento do shell para `overflow-x: hidden; overflow-y: visible;` e padronizei `min-height`/`height` do `sidebar` para evitar cortes verticais enquanto previne scroll horizontal global.
- Mantive o scroll horizontal controlado em componentes específicos (por exemplo ` .table-wrapper`) para que tabelas continuem a rolar localmente quando necessário.

### Testing
- Nenhum teste automatizado foi executado neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956cea1cb948327babcc9515819e99f)