### PR TITLE
Padroniza layout do admin e refatora seções de escalas no formulário de emissão

### DIFF
--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -48,6 +48,8 @@ body.dark-mode {
 .app-layout {
   display: flex;
   min-height: 100vh;
+  height: auto;
+  width: 100%;
   align-items: stretch;
 }
 
@@ -55,6 +57,8 @@ body.dark-mode {
   flex: 1;
   min-width: 0;
   min-height: 100vh;
+  height: auto;
+  width: 100%;
   margin: 0;
   padding: 1.5rem 2rem 2.5rem;
   background: var(--bg);
@@ -175,7 +179,7 @@ a:hover {
 
 .topbar h1 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 14px;
   font-weight: 700;
   color: var(--heading);
 }
@@ -203,7 +207,7 @@ a:hover {
 
 .page-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 14px;
   font-weight: 600;
   color: var(--heading);
 }
@@ -211,7 +215,7 @@ a:hover {
 .page-subtitle {
   margin: 0.25rem 0 0;
   color: var(--muted);
-  font-size: 1rem;
+  font-size: 12px;
 }
 
 .page-actions {
@@ -227,7 +231,7 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 16px;
+  padding: 14px;
   margin-bottom: 1.875rem;
 }
 
@@ -328,21 +332,21 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1rem 1.25rem;
+  padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  min-height: 160px;
+  min-height: 120px;
 }
 
 .stat-label {
-  font-size: 0.95rem;
+  font-size: 12px;
   color: var(--muted);
   font-weight: 600;
 }
 
 .stat-value {
-  font-size: 1.75rem;
+  font-size: 18px;
   font-weight: 800;
   color: var(--heading);
 }
@@ -367,11 +371,11 @@ a:hover {
 .data-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 1100px;
+  min-width: 720px;
 }
 
 .data-table--wide {
-  min-width: 1400px;
+  min-width: 980px;
 }
 
 .data-table th,
@@ -444,12 +448,18 @@ a:hover {
   display: grid;
   grid-template-columns: 160px 160px 200px 180px;
   gap: 12px;
+  align-items: end;
 }
 
 .filter-actions {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.filter-grid .form-actions {
+  grid-column: 1 / -1;
+  justify-content: flex-start;
 }
 
 .form-grid {
@@ -590,10 +600,10 @@ textarea {
     padding: 1rem;
   }
   .page-title {
-    font-size: 1.5rem;
+    font-size: 14px;
   }
   .stat-grid {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -629,6 +639,9 @@ textarea {
     justify-content: flex-start;
   }
   .stat-grid {
+    grid-template-columns: 1fr;
+  }
+  .form-grid {
     grid-template-columns: 1fr;
   }
   .table-wrapper {
@@ -809,7 +822,7 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .app-header__title {
-  font-size: 1.5rem;
+  font-size: 14px;
   font-weight: 600;
   color: #2d3748;
 }
@@ -967,5 +980,11 @@ body.sidebar-open .sidebar-overlay {
 
   .filter-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1200px) {
+  .stat-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -200,7 +200,7 @@ body.sidebar-open .app-shell .sidebar {
 }
 
 .app-header__title {
-  font-size: 1.5rem;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-heading);
   text-transform: capitalize;
@@ -306,8 +306,8 @@ body.sidebar-open .app-shell .sidebar {
 
 .page-title {
   margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
   color: #2d3748;
 }
 
@@ -458,21 +458,21 @@ body.dark-mode {
 }
 
 h1 {
-  font-size: 24px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
 }
 
 h2 {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 700;
 }
 
 h3 {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 p,
 span {
-  font-size: 14px;
+  font-size: 12px;
 }

--- a/gestao/static/gestao/formulario_base_gestao.css
+++ b/gestao/static/gestao/formulario_base_gestao.css
@@ -14,7 +14,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
-  padding: 16px;
+  padding: 14px;
   display: grid;
   gap: 1.25rem;
 }
@@ -42,7 +42,7 @@
   background: #fdfdff;
   border: 1px solid var(--border);
   border-radius: 14px;
-  padding: 16px;
+  padding: 14px;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
@@ -232,13 +232,13 @@ textarea:focus {
 .scale-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .scale-row,
 .scale-grid {
   display: grid;
-  grid-template-columns: 160px 180px 120px 36px;
+  grid-template-columns: 140px 160px 120px 36px;
   gap: 10px;
   align-items: center;
   padding: 8px;
@@ -330,6 +330,17 @@ textarea:focus {
   opacity: 0;
   overflow: hidden;
   transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+
+.section-card.collapse-section:not(.is-visible) {
+  padding: 0;
+  border: 0;
+  margin: 0;
+}
+
+.section-card.collapse-section.is-visible {
+  padding: 14px;
+  border: 1px solid var(--border);
 }
 
 .collapse-section.is-visible {

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -109,12 +109,6 @@
             </label>
             <p class="helper-text">Ative para adicionar escalas no voo de ida.</p>
         </div>
-        <div id="escala-ida-wrapper" class="collapse-section">
-            <input type="hidden" name="qtd_escalas_ida" id="id_qtd_escalas_ida" value="0" />
-            <input type="hidden" name="total_escalas_ida" id="id_total_escalas_ida" value="0" />
-            <div id="escalas-ida-container" class="scale-list"></div>
-            <button type="button" class="btn btn--outline btn--sm" data-add-escala="ida">+ Adicionar escala</button>
-        </div>
         <hr class="section-divider" />
         <div class="toggle-row">
             <label class="toggle-pill" for="possui-volta">
@@ -123,6 +117,20 @@
             </label>
             <p class="helper-text">Ative para informar o trecho de retorno.</p>
         </div>
+    </div>
+
+    <div id="escala-ida-wrapper" class="section-card collapse-section">
+        <div class="section-card__header">
+            <div>
+                <p class="eyebrow">Escalas</p>
+                <h2 class="section-card__title">Escalas do voo de ida</h2>
+                <p class="section-card__description">Adicione escalas somente quando o trecho exigir.</p>
+            </div>
+        </div>
+        <input type="hidden" name="qtd_escalas_ida" id="id_qtd_escalas_ida" value="0" />
+        <input type="hidden" name="total_escalas_ida" id="id_total_escalas_ida" value="0" />
+        <div id="escalas-ida-container" class="scale-list"></div>
+        <button type="button" class="btn btn--outline btn--sm" data-add-escala="ida">+ Adicionar escala</button>
     </div>
 
     <div id="voo-volta-card" class="section-card collapse-section">
@@ -147,12 +155,20 @@
             </label>
             <p class="helper-text">Ative para adicionar escalas no voo de volta.</p>
         </div>
-        <div id="escala-volta-wrapper" class="collapse-section">
-            <input type="hidden" name="qtd_escalas_volta" id="id_qtd_escalas_volta" value="0" />
-            <input type="hidden" name="total_escalas_volta" id="id_total_escalas_volta" value="0" />
-            <div id="escalas-volta-container" class="scale-list"></div>
-            <button type="button" class="btn btn--outline btn--sm" data-add-escala="volta">+ Adicionar escala</button>
+    </div>
+
+    <div id="escala-volta-wrapper" class="section-card collapse-section">
+        <div class="section-card__header">
+            <div>
+                <p class="eyebrow">Escalas</p>
+                <h2 class="section-card__title">Escalas do voo de volta</h2>
+                <p class="section-card__description">Use quando o retorno exigir trechos intermediários.</p>
+            </div>
         </div>
+        <input type="hidden" name="qtd_escalas_volta" id="id_qtd_escalas_volta" value="0" />
+        <input type="hidden" name="total_escalas_volta" id="id_total_escalas_volta" value="0" />
+        <div id="escalas-volta-container" class="scale-list"></div>
+        <button type="button" class="btn btn--outline btn--sm" data-add-escala="volta">+ Adicionar escala</button>
     </div>
 
     <div class="section-card">
@@ -302,6 +318,8 @@ const resumoValores = document.getElementById('resumo-valores');
 const possuiVoltaToggle = document.getElementById('possui-volta');
 const voltaCard = document.getElementById('voo-volta-card');
 const dataVoltaField = document.getElementById('id_data_volta');
+const escalaVoltaWrapper = document.getElementById('escala-volta-wrapper');
+const escalaVoltaToggle = document.getElementById('volta-tem-escala');
 
 if (lucroField) {
     lucroField.readOnly = true;
@@ -319,6 +337,14 @@ function setVoltaVisibility() {
     voltaCard.classList.toggle('is-visible', shouldShow);
     if (possuiVoltaToggle) {
         possuiVoltaToggle.checked = shouldShow;
+    }
+    if (!shouldShow) {
+        if (escalaVoltaToggle) {
+            escalaVoltaToggle.checked = false;
+        }
+        if (escalaVoltaWrapper) {
+            escalaVoltaWrapper.classList.remove('is-visible');
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Unificar tipografia, espaçamentos e alturas de componentes do admin para reduzir espaços em branco e melhorar consistência visual. 
- Garantir que containers principais ocupem toda a altura visível sem causar cortes nem rolagem horizontal indevida. 
- Padronizar altura de inputs e botões e tornar grades de filtro e tabelas mais responsivas. 
- Separar as escalas do formulário de emissão em cards dedicados para melhorar usabilidade e controle de visibilidade.

### Description
- Ajusta tamanhos e pesos de títulos e textos e normaliza layout shell em `gestao/static/gestao/css/layout.css` e `gestao/static/gestao/css/admin-theme.css` (h1/h2/h3, `page-title`, `app-header` e regras responsivas). 
- Reduz padding e altura de cards e estatísticas, diminui `min-width` das tabelas (`.data-table` e `.data-table--wide`) e atualiza grid de filtros (`.filter-grid`) para alinhar campos e ações. 
- Simplifica formulários em `gestao/static/gestao/formulario_base_gestao.css` (ajustes de padding, grids e regras para `.collapse-section`) e reduz gaps/colunas de painéis de escala. 
- Refatora `gestao/templates/admin_custom/form_emissao_passagem.html` para mover blocos de escalas para `section-card` separados, adicionar wrappers `escala-ida-wrapper`/`escala-volta-wrapper` e sincronizar visibilidade de escalas com o toggle de volta via pequenas alterações de JS.

### Testing
- Iniciou o servidor Django com `python manage.py runserver` e capturou uma captura de tela da página de login do admin via Playwright; a página foi carregada e a captura foi gerada com sucesso. 
- Nenhuma suíte de testes automatizados (unit/integration) foi executada neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d21088b483279ab328d4c0e814cf)