### PR TITLE
Compact CSS spacing and radius across dashboards

### DIFF
--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -10,7 +10,7 @@
   --success: #16a34a;
   --warning: #d97706;
   --danger: #dc2626;
-  --radius: 16px;
+  --radius: 6px;
   --shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
   --page-max-width: 100%;
 }
@@ -60,7 +60,7 @@ body.dark-mode {
   height: auto;
   width: 100%;
   margin: 0;
-  padding: 1.5rem 2rem 2.5rem;
+  padding: 1rem 1.25rem 1.5rem;
   background: var(--bg);
 }
 
@@ -72,7 +72,7 @@ body.dark-mode {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 /* ===== Sidebar ===== */
@@ -111,7 +111,7 @@ body.dark-mode {
   margin: 0.75rem auto 1.5rem;
   width: 40px;
   height: 40px;
-  border-radius: 12px;
+  border-radius: 6px;
   background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
   font-size: 1.1rem;
@@ -159,7 +159,7 @@ a:hover {
   padding: 0 0 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
   min-height: 100vh;
   height: auto;
   overflow-x: hidden;
@@ -170,7 +170,7 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1rem 1.25rem;
+  padding: 12px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -197,7 +197,7 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1.25rem 1.5rem;
+  padding: 12px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -221,7 +221,7 @@ a:hover {
 .page-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
@@ -231,8 +231,8 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 14px;
-  margin-bottom: 1.875rem;
+  padding: 12px;
+  margin-bottom: 1rem;
 }
 
 .section-heading {
@@ -240,7 +240,7 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .section-title {
@@ -323,7 +323,7 @@ a:hover {
 
 .stat-grid {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
@@ -332,10 +332,10 @@ a:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 0.85rem 1rem;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
   min-height: 120px;
 }
 
@@ -346,7 +346,7 @@ a:hover {
 }
 
 .stat-value {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 800;
   color: var(--heading);
 }
@@ -380,7 +380,7 @@ a:hover {
 
 .data-table th,
 .data-table td {
-  padding: 0.85rem 0.75rem;
+  padding: 8px 12px;
   text-align: left;
   border-bottom: 1px solid var(--border);
 }
@@ -391,6 +391,11 @@ a:hover {
   font-weight: 700;
   position: sticky;
   top: 0;
+  font-size: 12px;
+}
+
+.data-table td {
+  font-size: 13px;
 }
 
 .data-table tbody tr:hover {
@@ -401,19 +406,19 @@ a:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 1rem;
+  margin-top: 0.75rem;
   color: var(--muted);
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .pill {
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
   font-weight: 700;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 .pill-success {
@@ -436,24 +441,24 @@ a:hover {
 .filter-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .filter-body {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .filter-grid {
   display: grid;
   grid-template-columns: 160px 160px 200px 180px;
-  gap: 12px;
+  gap: 8px;
   align-items: end;
 }
 
 .filter-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
 }
 
@@ -464,14 +469,14 @@ a:hover {
 
 .form-grid {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .form-label {
@@ -499,6 +504,7 @@ textarea {
   background: #f8fafc;
   color: var(--heading);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  max-width: 500px;
 }
 
 input[type="text"],
@@ -507,7 +513,7 @@ input[type="password"],
 input[type="date"],
 input[type="datetime-local"],
 select {
-  height: 36px;
+  height: 32px;
 }
 
 input:focus,
@@ -530,7 +536,7 @@ textarea {
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin-top: 0.25rem;
   flex-wrap: wrap;
 }
@@ -544,7 +550,7 @@ textarea {
 .section-divider {
   height: 1px;
   background: var(--border);
-  margin: 0.75rem 0;
+  margin: 0.5rem 0;
 }
 
 .list-plain {
@@ -559,8 +565,8 @@ textarea {
 }
 
 .alert {
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
+  padding: 12px;
+  border-radius: 6px;
   border: 1px solid transparent;
   font-weight: 600;
 }
@@ -585,7 +591,7 @@ textarea {
 
 .stacked {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 @media (min-width: 768px) {
@@ -719,7 +725,7 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 24px;
+  padding: 16px;
   border-bottom: 1px solid var(--shell-border);
 }
 
@@ -730,7 +736,7 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .sidebar-nav {
-  margin-top: 24px;
+  margin-top: 16px;
   display: flex;
   flex-direction: column;
 }
@@ -739,7 +745,7 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 24px;
+  padding: 10px 16px;
   color: var(--shell-muted);
   text-decoration: none;
   transition: color 0.2s, background 0.2s;
@@ -777,18 +783,18 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .nav-subitems {
-  margin-left: 16px;
+  margin-left: 12px;
   display: flex;
   flex-direction: column;
 }
 
 .sidebar-divider {
-  margin: 16px 24px 8px;
+  margin: 12px 16px 6px;
   border-top: 1px solid var(--shell-border);
 }
 
 .sidebar-section {
-  margin: 0 24px 8px;
+  margin: 0 16px 6px;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -809,7 +815,7 @@ body.sidebar-open .sidebar-overlay {
   background: var(--shell-surface);
   border-bottom: 1px solid var(--shell-border);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  padding: 16px 24px;
+  padding: 12px 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -830,7 +836,7 @@ body.sidebar-open .sidebar-overlay {
 .app-header__actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .user-name {
@@ -842,7 +848,7 @@ body.sidebar-open .sidebar-overlay {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 24px;
+  padding: 16px;
   background: var(--shell-bg);
   width: 100%;
 }
@@ -851,8 +857,8 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
+  gap: 12px;
+  margin-bottom: 16px;
   flex-wrap: wrap;
 }
 
@@ -861,7 +867,7 @@ body.sidebar-open .sidebar-overlay {
   height: 32px;
   border: none;
   background: transparent;
-  border-radius: 8px;
+  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -963,7 +969,7 @@ body.sidebar-open .sidebar-overlay {
 
 @media (max-width: 640px) {
   .app-main {
-    padding: 20px;
+    padding: 16px;
   }
 }
 

--- a/gestao/static/gestao/css/base/variables.css
+++ b/gestao/static/gestao/css/base/variables.css
@@ -13,7 +13,9 @@
   --color-surface-active: #ebf4ff;
   --color-input-bg: #edf2f7;
   --color-input-border: #cbd5e0;
-  --radius-lg: 0.75rem;
+  --radius: 6px;
+  --radius-md: 6px;
+  --radius-lg: 6px;
 }
 
 body.dark-mode {

--- a/gestao/static/gestao/css/layout.css
+++ b/gestao/static/gestao/css/layout.css
@@ -106,7 +106,7 @@ body.sidebar-open .app-shell .sidebar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 24px;
+  padding: 16px;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -120,7 +120,7 @@ body.sidebar-open .app-shell .sidebar {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 24px;
+  padding: 10px 16px;
   text-decoration: none;
   color: var(--color-muted);
   transition: color 0.2s, background 0.2s;
@@ -182,7 +182,7 @@ body.sidebar-open .app-shell .sidebar {
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  padding: 16px 24px;
+  padding: 12px 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -209,7 +209,7 @@ body.sidebar-open .app-shell .sidebar {
 .app-header__actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .user-name {
@@ -218,7 +218,7 @@ body.sidebar-open .app-shell .sidebar {
 }
 
 .sidebar-nav {
-  margin-top: 24px;
+  margin-top: 16px;
   display: flex;
   flex-direction: column;
 }
@@ -238,7 +238,7 @@ body.sidebar-open .app-shell .sidebar {
   overflow-y: auto;
   overflow-x: hidden;
   margin-left: 0;
-  padding: 24px;
+  padding: 16px;
   background: var(--color-bg);
   width: 100%;
 }
@@ -255,7 +255,7 @@ body.sidebar-open .app-shell .sidebar {
   height: 32px;
   border: none;
   background: transparent;
-  border-radius: 8px;
+  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -343,7 +343,7 @@ body.sidebar-open .app-shell .sidebar {
   }
 
   .app-main {
-    padding: 24px 16px;
+    padding: 16px 12px;
   }
 }
 
@@ -378,7 +378,7 @@ body.sidebar-open .app-shell .sidebar {
   }
 
   .app-main {
-    padding: 20px;
+    padding: 16px;
   }
 }
 
@@ -424,13 +424,13 @@ body.dark-mode {
 .fpp-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 .fpp-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 16px;
+  gap: 12px;
 }
 
 @media (min-width: 768px) {
@@ -447,8 +447,8 @@ body.dark-mode {
 
 .fpp-card {
   background: #ffffff;
-  border-radius: 12px;
-  padding: 16px;
+  border-radius: 6px;
+  padding: 12px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 

--- a/gestao/static/gestao/css/login.css
+++ b/gestao/static/gestao/css/login.css
@@ -21,7 +21,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: 16px;
   font-size: 16px;
   line-height: 1.6;
 }
@@ -38,9 +38,9 @@ body {
 /* ========== CARD DE LOGIN ========== */
 .login-container {
   background: #ffffff;
-  border-radius: 16px;
+  border-radius: 6px;
   box-shadow: 0 8px 32px rgba(51, 102, 153, 0.08);
-  padding: 50px 40px;
+  padding: 24px;
   width: 100%;
   max-width: 420px;
   animation: slideIn 0.6s ease-out;
@@ -114,7 +114,7 @@ label {
   font-size: 13px;
   font-weight: 600;
   color: #4a6fa5;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -124,11 +124,11 @@ input[type="text"],
 input[type="password"],
 select {
   width: 100%;
-  padding: 14px 16px;
-  margin-bottom: 20px;
+  padding: 6px 10px;
+  margin-bottom: 12px;
   border: 2px solid #d4e4f0;
-  border-radius: 10px;
-  font-size: 15px;
+  border-radius: 6px;
+  font-size: 14px;
   color: #2c3e50;
   background: #f8fbfd;
   transition: all 0.3s ease;
@@ -136,6 +136,8 @@ select {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  max-width: 500px;
+  height: 32px;
 }
 
 /* Placeholder */
@@ -166,20 +168,20 @@ select {
   background-repeat: no-repeat;
   background-position: right 12px center;
   background-size: 20px;
-  padding-right: 40px;
+  padding-right: 32px;
 }
 
 /* ========== BOTÃO ========== */
 button[type="submit"],
 button {
   width: 100%;
-  padding: 14px;
-  margin-top: 8px;
+  padding: 10px;
+  margin-top: 6px;
   border: none;
-  border-radius: 10px;
+  border-radius: 6px;
   background: linear-gradient(135deg, #5a8cc4 0%, #4a7ab8 100%);
   color: #ffffff;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -243,10 +245,10 @@ body.dark-mode button[type="submit"] {
 .erro {
   background: #fce8e8;
   color: #c85a5a;
-  padding: 12px 16px;
-  border-radius: 8px;
-  margin-bottom: 20px;
-  font-size: 14px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  font-size: 13px;
   border-left: 4px solid #c85a5a;
   animation: shake 0.5s ease-in-out;
 }
@@ -266,9 +268,9 @@ body.dark-mode button[type="submit"] {
   }
 
   .login-container {
-    padding: 40px 30px;
+    padding: 20px 18px;
     max-width: 100%;
-    border-radius: 14px;
+    border-radius: 6px;
   }
 
   .login-container h2 {
@@ -283,23 +285,23 @@ body.dark-mode button[type="submit"] {
 
   label {
     font-size: 12px;
-    margin-bottom: 6px;
+    margin-bottom: 4px;
   }
 
   input[type="text"],
   input[type="password"],
   select {
-    padding: 12px 14px;
-    margin-bottom: 18px;
-    font-size: 16px;
-    border-radius: 8px;
+    padding: 6px 10px;
+    margin-bottom: 12px;
+    font-size: 14px;
+    border-radius: 6px;
   }
 
   button[type="submit"],
   button {
-    padding: 12px;
-    font-size: 15px;
-    margin-top: 6px;
+    padding: 10px;
+    font-size: 14px;
+    margin-top: 4px;
   }
 }
 
@@ -308,18 +310,18 @@ body.dark-mode button[type="submit"] {
    ============================================ */
 @media (max-width: 480px) {
   body {
-    padding: 12px;
+    padding: 10px;
     min-height: 100vh;
   }
 
   .login-page {
     min-height: auto;
-    padding: 20px 0;
+    padding: 12px 0;
   }
 
   .login-container {
-    padding: 32px 20px;
-    border-radius: 12px;
+    padding: 18px 16px;
+    border-radius: 6px;
     box-shadow: 0 4px 16px rgba(51, 102, 153, 0.06);
     max-width: 100%;
   }
@@ -336,26 +338,26 @@ body.dark-mode button[type="submit"] {
 
   .login-container p {
     font-size: 12px;
-    margin-bottom: 20px;
+    margin-bottom: 12px;
   }
 
   label {
     font-size: 11px;
-    margin-bottom: 4px;
+    margin-bottom: 3px;
   }
 
   input[type="text"],
   input[type="password"],
   select {
-    padding: 11px 12px;
-    margin-bottom: 14px;
-    font-size: 16px;
+    padding: 6px 10px;
+    margin-bottom: 10px;
+    font-size: 14px;
     border-radius: 6px;
   }
 
   button[type="submit"],
   button {
-    padding: 11px;
+    padding: 9px;
     font-size: 14px;
     margin-top: 4px;
     border-radius: 6px;
@@ -367,8 +369,8 @@ body.dark-mode button[type="submit"] {
   }
 
   .erro {
-    padding: 10px 12px;
-    margin-bottom: 16px;
+    padding: 8px 10px;
+    margin-bottom: 12px;
     font-size: 13px;
     border-radius: 6px;
   }
@@ -379,7 +381,7 @@ body.dark-mode button[type="submit"] {
    ============================================ */
 @media (max-width: 360px) {
   .login-container {
-    padding: 24px 16px;
+    padding: 16px 12px;
   }
 
   .login-container h2 {
@@ -399,14 +401,14 @@ body.dark-mode button[type="submit"] {
   input[type="text"],
   input[type="password"],
   select {
-    padding: 10px 10px;
-    margin-bottom: 12px;
-    font-size: 16px;
+    padding: 6px 10px;
+    margin-bottom: 10px;
+    font-size: 14px;
   }
 
   button[type="submit"],
   button {
-    padding: 10px;
+    padding: 9px;
     font-size: 13px;
   }
 }
@@ -416,13 +418,13 @@ body.dark-mode button[type="submit"] {
    ============================================ */
 @media (min-width: 1024px) {
   body {
-    padding: 40px;
+    padding: 24px;
   }
 
   .login-container {
-    padding: 60px 50px;
+    padding: 28px 24px;
     max-width: 480px;
-    border-radius: 20px;
+    border-radius: 6px;
     box-shadow: 0 12px 40px rgba(51, 102, 153, 0.1);
   }
 
@@ -432,41 +434,41 @@ body.dark-mode button[type="submit"] {
   }
 
   .login-container h2 {
-    font-size: 32px;
-    margin-bottom: 16px;
+    font-size: 24px;
+    margin-bottom: 10px;
   }
 
   .login-container p {
-    font-size: 15px;
-    margin-bottom: 40px;
+    font-size: 14px;
+    margin-bottom: 16px;
   }
 
   label {
-    font-size: 14px;
-    margin-bottom: 10px;
+    font-size: 12px;
+    margin-bottom: 4px;
   }
 
   input[type="text"],
   input[type="password"],
   select {
-    padding: 16px 18px;
-    margin-bottom: 24px;
-    font-size: 16px;
-    border-radius: 12px;
+    padding: 6px 10px;
+    margin-bottom: 12px;
+    font-size: 14px;
+    border-radius: 6px;
   }
 
   button[type="submit"],
   button {
-    padding: 16px;
-    font-size: 17px;
-    margin-top: 12px;
-    border-radius: 12px;
+    padding: 10px;
+    font-size: 14px;
+    margin-top: 6px;
+    border-radius: 6px;
   }
 
   button[type="submit"]:hover,
   button:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 25px rgba(90, 140, 196, 0.4);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 18px rgba(90, 140, 196, 0.35);
   }
 }
 
@@ -476,7 +478,7 @@ body.dark-mode button[type="submit"] {
 @media (min-width: 1440px) {
   .login-container {
     max-width: 520px;
-    padding: 70px 60px;
+    padding: 32px 28px;
   }
 
   .login-logo {
@@ -494,14 +496,14 @@ body.dark-mode button[type="submit"] {
   input[type="text"],
   input[type="password"],
   select {
-    padding: 18px 20px;
-    font-size: 17px;
+    padding: 6px 10px;
+    font-size: 14px;
   }
 
   button[type="submit"],
   button {
-    padding: 18px;
-    font-size: 18px;
+    padding: 10px;
+    font-size: 14px;
   }
 }
 
@@ -526,7 +528,7 @@ body.dark-mode button[type="submit"] {
   }
 
   .login-container {
-    padding: 30px 25px;
+    padding: 16px 14px;
     max-width: 100%;
   }
 
@@ -548,9 +550,9 @@ body.dark-mode button[type="submit"] {
   input[type="text"],
   input[type="password"],
   select {
-    padding: 8px 10px;
+    padding: 6px 10px;
     margin-bottom: 10px;
-    font-size: 14px;
+    font-size: 13px;
   }
 
   button[type="submit"],

--- a/gestao/static/gestao/css/painel.css
+++ b/gestao/static/gestao/css/painel.css
@@ -10,7 +10,7 @@
   --muted: #7a92a8;
   --heading: #2c5aa0;
   --primary: #5a8cc4;
-  --radius: 10px;
+  --radius: 6px;
   --shadow: 0 2px 8px rgba(51, 102, 153, 0.08);
 }
 
@@ -81,7 +81,7 @@ body.dark-mode .sidebar {
 /* ========== CONTEÚDO PRINCIPAL ========== */
 main, .main-content {
   margin-left: 210px;
-  padding: 15px;
+  padding: 16px;
   min-height: 100vh;
   overflow-y: auto;
 }
@@ -89,9 +89,9 @@ main, .main-content {
 /* ========== HEADER ========== */
 header, .header {
   background: var(--surface);
-  padding: 12px 15px;
+  padding: 10px 12px;
   box-shadow: var(--shadow);
-  margin-bottom: 15px;
+  margin-bottom: 12px;
   border-radius: var(--radius);
   display: flex;
   justify-content: space-between;
@@ -117,8 +117,8 @@ header .user-info, .header .user-info {
 .card, .panel {
   background: var(--surface);
   border-radius: var(--radius);
-  padding: 20px;
-  margin-bottom: 20px;
+  padding: 12px;
+  margin-bottom: 16px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
   transition: all 0.3s ease;
@@ -151,14 +151,14 @@ p, span {
 }
 
 .section {
-  margin-bottom: 30px;
+  margin-bottom: 16px;
 }
 
 /* ========== FORMULÁRIOS ========== */
 form {
   background: var(--surface);
   border-radius: var(--radius);
-  padding: 18px;
+  padding: 12px;
   margin-bottom: 15px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
@@ -166,8 +166,8 @@ form {
 
 fieldset {
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px;
+  border-radius: 6px;
+  padding: 8px;
   margin-bottom: 15px;
 }
 
@@ -214,7 +214,7 @@ input[type="tel"],
 select,
 textarea {
   width: 100%;
-  padding: 10px 12px;
+  padding: 6px 10px;
   border: 2px solid var(--border);
   border-radius: 6px;
   font-size: 13px;
@@ -225,6 +225,18 @@ textarea {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  max-width: 500px;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="date"],
+input[type="time"],
+input[type="tel"],
+select {
+  height: 32px;
 }
 
 input::placeholder, textarea::placeholder {
@@ -254,8 +266,8 @@ select {
 /* ========== FORM ROW ========== */
 .form-row {
   display: flex;
-  gap: 14px;
-  margin-bottom: 14px;
+  gap: 10px;
+  margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
@@ -268,7 +280,7 @@ select {
 .form-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 14px;
+  gap: 10px;
 }
 
 .form-columns .form-group {
@@ -278,7 +290,7 @@ select {
 .form-columns-3 {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  gap: 14px;
+  gap: 10px;
 }
 
 .form-columns-3 .form-group {
@@ -288,9 +300,9 @@ select {
 /* ========== FORM ACTIONS ========== */
 .form-actions, .form-buttons {
   display: flex;
-  gap: 10px;
-  margin-top: 16px;
-  padding-top: 16px;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
   border-top: 1px solid var(--border);
   justify-content: flex-end;
 }
@@ -374,19 +386,19 @@ thead {
 }
 
 thead th {
-  padding: 10px 12px;
+  padding: 8px 12px;
   text-align: left;
   font-weight: 600;
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 
 tbody td {
-  padding: 10px 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--border);
   color: var(--heading);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 tbody tr:hover {
@@ -488,11 +500,12 @@ body.dark-mode .btn-delete {
 .filter-group input,
 .filter-group select {
   width: 100%;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border: 2px solid var(--border);
   border-radius: 6px;
   font-size: 12px;
   background: var(--surface);
+  max-width: 500px;
 }
 
 .filter-group input:focus,
@@ -504,14 +517,14 @@ body.dark-mode .btn-delete {
 
 .filter-buttons, .filter-actions {
   display: flex;
-  gap: 10px;
-  margin-top: 10px;
+  gap: 8px;
+  margin-top: 8px;
   flex-wrap: wrap;
 }
 
 .filter-buttons button, .filter-actions button {
-  padding: 10px 20px;
-  height: 44px;
+  padding: 8px 16px;
+  height: 36px;
   flex: 1;
   min-width: 120px;
   font-size: 12px;
@@ -568,10 +581,10 @@ body.dark-mode .btn-delete {
 }
 
 .kpi-value, .indicator-value, .metric-value {
-  font-size: 24px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--heading);
-  margin: 6px 0;
+  margin: 4px 0;
 }
 
 .kpi-label, .indicator-label, .metric-label {
@@ -586,8 +599,8 @@ body.dark-mode .btn-delete {
 .row {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: 8px;
+  margin-bottom: 10px;
 }
 
 .col-3 { flex: 0 0 calc(25% - 9px); }
@@ -597,8 +610,8 @@ body.dark-mode .btn-delete {
 
 .painel-cards {
   display: grid;
-  gap: 16px;
-  margin-bottom: 20px;
+  gap: 12px;
+  margin-bottom: 16px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
@@ -710,7 +723,7 @@ body.dark-mode .btn-delete {
   }
 
   .kpi-value, .indicator-value, .metric-value {
-    font-size: 20px;
+    font-size: 16px;
   }
 }
 
@@ -771,7 +784,7 @@ body.dark-mode .btn-delete {
   }
 
   .kpi-value, .indicator-value, .metric-value {
-    font-size: 18px;
+    font-size: 15px;
   }
 
   h2 { font-size: 16px; }

--- a/gestao/static/gestao/formulario_base_gestao.css
+++ b/gestao/static/gestao/formulario_base_gestao.css
@@ -6,7 +6,7 @@
   --heading: #0f172a;
   --primary: #2563eb;
   --primary-strong: #1d4ed8;
-  --radius: 16px;
+  --radius: 6px;
 }
 
 .form-wrapper {
@@ -14,9 +14,9 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
-  padding: 14px;
+  padding: 12px;
   display: grid;
-  gap: 1.25rem;
+  gap: 0.75rem;
 }
 
 .form-title {
@@ -35,25 +35,25 @@
 .form-shell {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .section-card {
   background: #fdfdff;
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 14px;
+  border-radius: 6px;
+  padding: 12px;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .section-card__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
@@ -80,7 +80,7 @@
 .form-group,
 .section-grid {
   display: grid;
-  gap: 12px;
+  gap: 8px;
   grid-template-columns: 180px 180px 200px;
 }
 
@@ -100,7 +100,7 @@
 .form-grid--dates {
   display: grid;
   grid-template-columns: 220px 160px;
-  gap: 12px;
+  gap: 8px;
 }
 
 .form-label {
@@ -127,6 +127,7 @@ textarea {
   background: #f8fafc;
   color: var(--heading);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  max-width: 500px;
 }
 
 input[type="text"],
@@ -136,7 +137,7 @@ input[type="date"],
 input[type="datetime-local"],
 input[type="time"],
 select {
-  height: 36px;
+  height: 32px;
 }
 
 textarea {
@@ -155,7 +156,7 @@ textarea:focus {
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
   padding: 12px 0 0;
   border-top: 1px solid var(--border);
@@ -171,7 +172,7 @@ textarea:focus {
   font-weight: 600;
   border: none;
   border-radius: 6px;
-  height: 36px;
+  height: 32px;
   padding: 0 14px;
   font-size: 12px;
   cursor: pointer;
@@ -200,20 +201,20 @@ textarea:focus {
 
 .summary-grid {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .summary-pill {
   border: 1px solid var(--border);
   background: #f8fafc;
-  border-radius: 12px;
-  padding: 0.85rem 1rem;
+  border-radius: 6px;
+  padding: 12px;
   font-weight: 700;
   color: var(--heading);
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
   min-height: 90px;
 }
 
@@ -226,23 +227,23 @@ textarea:focus {
 .scale-panels {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 12px;
+  gap: 8px;
 }
 
 .scale-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .scale-row,
 .scale-grid {
   display: grid;
   grid-template-columns: 140px 160px 120px 36px;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
   padding: 8px;
-  border-radius: 10px;
+  border-radius: 6px;
   border: 1px dashed var(--border);
   background: #ffffff;
 }
@@ -257,8 +258,8 @@ textarea:focus {
   border: 1px solid var(--border);
   background: #ffffff;
   border-radius: 6px;
-  height: 36px;
-  width: 36px;
+  height: 32px;
+  width: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -272,12 +273,12 @@ textarea:focus {
 
 .scale-card {
   border: 1px dashed var(--border);
-  border-radius: 12px;
-  padding: 1rem;
+  border-radius: 6px;
+  padding: 12px;
   background: #f8fafc;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin-left: 0.5rem;
   position: relative;
 }
@@ -295,7 +296,7 @@ textarea:focus {
 
 .toggle-row {
   display: flex;
-  gap: 0.65rem;
+  gap: 0.5rem;
   align-items: flex-start;
 }
 
@@ -339,7 +340,7 @@ textarea:focus {
 }
 
 .section-card.collapse-section.is-visible {
-  padding: 14px;
+  padding: 12px;
   border: 1px solid var(--border);
 }
 
@@ -352,8 +353,8 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
+  padding: 0.4rem 0.65rem;
+  border-radius: 6px;
   border: 1px solid var(--border);
   background: #f8fafc;
   font-weight: 600;
@@ -362,7 +363,7 @@ textarea:focus {
 
 @media (max-width: 640px) {
   .form-wrapper {
-    padding: 1rem;
+    padding: 0.75rem;
   }
 
   .section-card__header {

--- a/painel_cliente/static/painel_cliente/css/base/typography.css
+++ b/painel_cliente/static/painel_cliente/css/base/typography.css
@@ -34,7 +34,7 @@ h2 {
 }
 
 .valor {
-  font-size: 1.4rem;
+  font-size: 1.1rem;
   font-weight: 700;
 }
 

--- a/painel_cliente/static/painel_cliente/css/base/variables.css
+++ b/painel_cliente/static/painel_cliente/css/base/variables.css
@@ -18,16 +18,16 @@
   --shadow-table: 0 10px 8px rgba(0, 0, 0, 0.1);
   --shadow-login: 0 2px 32px rgba(0, 0, 0, 0.1);
 
-  --radius-lg: 18px;
-  --radius-md: 12px;
-  --radius-sm: 9px;
-  --radius-xs: 8px;
+  --radius-lg: 6px;
+  --radius-md: 6px;
+  --radius-sm: 4px;
+  --radius-xs: 4px;
 
-  --space-xs: 6px;
-  --space-sm: 12px;
-  --space-md: 16px;
-  --space-lg: 20px;
-  --space-xl: 30px;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 14px;
+  --space-xl: 20px;
 }
 
 body.dark-mode {

--- a/painel_cliente/static/painel_cliente/css/components/cards.css
+++ b/painel_cliente/static/painel_cliente/css/components/cards.css
@@ -1,6 +1,6 @@
 .card {
   background: var(--color-surface);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
   display: flex;
@@ -9,24 +9,24 @@
 }
 
 .card-header {
-  padding: 24px 24px 12px;
+  padding: 12px 12px 8px;
 }
 
 .card-title {
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: 600;
   color: var(--color-heading);
 }
 
 .card-content {
-  padding: 0 24px 16px;
+  padding: 0 12px 12px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .card-actions {
-  padding: 0 24px 24px;
+  padding: 0 12px 12px;
 }
 
 .card a {

--- a/painel_cliente/static/painel_cliente/css/components/forms.css
+++ b/painel_cliente/static/painel_cliente/css/components/forms.css
@@ -1,6 +1,6 @@
 label {
   display: block;
-  margin: 12px 0 6px;
+  margin: 8px 0 4px;
   color: #2d3748;
   text-align: left;
   font-size: 0.875rem;
@@ -10,15 +10,16 @@ input[type="text"],
 input[type="password"],
 select {
   width: 100%;
-  height: 40px;
-  padding: 0 12px;
+  height: 32px;
+  padding: 6px 10px;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   margin-bottom: 12px;
   background: var(--color-input-bg);
   color: var(--color-text);
   font-size: 0.875rem;
   transition: border-color 0.2s, box-shadow 0.2s;
+  max-width: 500px;
 }
 
 input[type="text"]:focus-visible,
@@ -31,5 +32,5 @@ select:focus-visible {
 
 .erro {
   color: var(--color-danger);
-  margin-top: 12px;
+  margin-top: 8px;
 }

--- a/painel_cliente/static/painel_cliente/css/components/tables.css
+++ b/painel_cliente/static/painel_cliente/css/components/tables.css
@@ -2,16 +2,16 @@ table {
   width: 100%;
   border-collapse: collapse;
   background: var(--color-surface);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   overflow: hidden;
-  margin-bottom: 32px;
+  margin-bottom: 16px;
   border: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgba(15, 23, 42, 0.06);
 }
 
 th,
 td {
-  padding: 10px;
+  padding: 8px 12px;
   text-align: left;
 }
 
@@ -19,6 +19,7 @@ th {
   background: var(--color-primary-dark);
   color: var(--color-surface);
   font-weight: 600;
+  font-size: 12px;
 }
 
 tr {
@@ -31,6 +32,7 @@ tr:last-child {
 
 td {
   color: var(--color-text);
+  font-size: 13px;
 }
 
 .table-empty {

--- a/painel_cliente/static/painel_cliente/css/layout/layout.css
+++ b/painel_cliente/static/painel_cliente/css/layout/layout.css
@@ -42,7 +42,7 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 24px;
+  padding: 16px;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -53,7 +53,7 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .sidebar-nav {
-  margin-top: 24px;
+  margin-top: 16px;
   display: flex;
   flex-direction: column;
 }
@@ -62,7 +62,7 @@ body.sidebar-open .sidebar-overlay {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 24px;
+  padding: 10px 16px;
   text-decoration: none;
   color: var(--color-muted);
   transition: color 0.2s, background 0.2s;
@@ -93,7 +93,7 @@ body.sidebar-open .sidebar-overlay {
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  padding: 16px 24px;
+  padding: 12px 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -118,7 +118,7 @@ body.sidebar-open .sidebar-overlay {
 .app-header__actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .user-name {
@@ -129,7 +129,7 @@ body.sidebar-open .sidebar-overlay {
 .app-main {
   flex: 1;
   overflow: auto;
-  padding: 24px;
+  padding: 16px;
 }
 
 .app-shell .btn,
@@ -144,7 +144,7 @@ body.sidebar-open .sidebar-overlay {
   height: 32px;
   border: none;
   background: transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -170,13 +170,13 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .section-header {
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
 .painel-cards {
   display: grid;
-  gap: 16px;
-  margin-bottom: 30px;
+  gap: 12px;
+  margin-bottom: 16px;
 }
 
 .painel-cards.programas-grid {
@@ -184,7 +184,7 @@ body.sidebar-open .sidebar-overlay {
 }
 
 .page-actions {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .status-message {
@@ -196,7 +196,7 @@ body.sidebar-open .sidebar-overlay {
   justify-content: center;
   align-items: center;
   min-height: calc(100vh - 120px);
-  padding: 24px 0;
+  padding: 16px 0;
 }
 
 @media (min-width: 1024px) {
@@ -261,6 +261,6 @@ body.sidebar-open .sidebar-overlay {
   }
 
   .app-main {
-    padding: 20px;
+    padding: 16px;
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce excessive whitespace and large border radii across the management (Gestão) and client dashboard (Painel do Cliente) UIs to create a denser, more information-dense layout.
- Standardize spacing variables so components (cards, tables, forms, grids) follow a consistent compact system across both codebases.
- Make forms and input fields less visually oversized and prevent very wide inputs on large screens.

### Description
- Normalized radius and spacing variables in `gestao/static/gestao/css/base/variables.css` and `painel_cliente/static/painel_cliente/css/base/variables.css` to smaller values (radii ~4–6px and spaces reduced ~30%).
- Reduced paddings/gaps and font sizes for tables, cards and KPI/value elements across `painel_cliente/*` and `gestao/*` (table cell padding to `8px 12px`, table fonts to `13px` body / `12px` header, card paddings standardized to ~`12px`, KPI/value sizes reduced).
- Compacted form controls by setting input/select `height: 32px`, `padding: 6px 10px`, added `max-width: 500px` for fields, and constrained various grid/gap values in `formulario_base_gestao.css`, `painel.css`, and layout files.
- Tightened layout containers and utility spacing by reducing `.app-main`, `main`, `.page-container` paddings from `24px` to `16px`, lowering grid gaps and other margins in `layout.css` and `admin-theme.css`.

### Testing
- Started the Django development server with `python manage.py runserver` to verify the app boots, which completed successfully.
- Captured a visual smoke test of the login page using a Playwright script that produced a screenshot artifact (`artifacts/login.png`) to validate layout changes rendered without runtime errors.
- No automated unit or snapshot tests were run for these visual/CSS changes (visual verification only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae64824988327bc731fc9272fc53d)