### PR TITLE
Add 'Alertas de Passagens' feature (AlertaViagem) with admin CRUD and vitrine

### DIFF
--- a/gestao/migrations/0030_alerta_viagem_notificacao_sistema.py
+++ b/gestao/migrations/0030_alerta_viagem_notificacao_sistema.py
@@ -1,0 +1,48 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gestao", "0029_emissaopassagem_custo_total_criado_em_valor_taxas"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AlertaViagem",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("titulo", models.CharField(max_length=255)),
+                ("conteudo", models.TextField()),
+                ("continente", models.CharField(max_length=60)),
+                ("pais", models.CharField(max_length=120)),
+                ("cidade_destino", models.CharField(max_length=120)),
+                ("origem", models.CharField(max_length=10)),
+                ("destino", models.CharField(max_length=10)),
+                ("classe", models.CharField(choices=[("economica", "Econômica"), ("executiva", "Executiva")], max_length=20)),
+                ("programa_fidelidade", models.CharField(max_length=120)),
+                ("companhia_aerea", models.CharField(max_length=120)),
+                ("valor_milhas", models.IntegerField(blank=True, null=True)),
+                ("valor_reais", models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True)),
+                ("datas_ida", models.JSONField(blank=True, default=list)),
+                ("datas_volta", models.JSONField(blank=True, default=list)),
+                ("ativo", models.BooleanField(default=True)),
+                ("criado_em", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-criado_em"],
+            },
+        ),
+        migrations.CreateModel(
+            name="NotificacaoSistema",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("titulo", models.CharField(max_length=255)),
+                ("mensagem", models.TextField()),
+                ("criado_em", models.DateTimeField(auto_now_add=True)),
+                ("lida", models.BooleanField(default=False)),
+            ],
+            options={
+                "ordering": ["-criado_em"],
+            },
+        ),
+    ]

--- a/gestao/models/__init__.py
+++ b/gestao/models/__init__.py
@@ -16,6 +16,8 @@ from .companhia_aerea import CompanhiaAerea
 from .emissor_parceiro import EmissorParceiro
 from .passageiro_frequente import PassageiroFrequente
 from .audit_log import AuditLog
+from .alerta_viagem import AlertaViagem
+from .notificacao_sistema import NotificacaoSistema
 
 __all__ = [
     'Cliente',
@@ -36,4 +38,6 @@ __all__ = [
     'EmissorParceiro',
     'PassageiroFrequente',
     'AuditLog',
+    'AlertaViagem',
+    'NotificacaoSistema',
 ]

--- a/gestao/models/alerta_viagem.py
+++ b/gestao/models/alerta_viagem.py
@@ -1,0 +1,33 @@
+from django.db import models
+
+
+class AlertaViagem(models.Model):
+    CLASSE_ECONOMICA = "economica"
+    CLASSE_EXECUTIVA = "executiva"
+    CLASSE_CHOICES = [
+        (CLASSE_ECONOMICA, "Econômica"),
+        (CLASSE_EXECUTIVA, "Executiva"),
+    ]
+
+    titulo = models.CharField(max_length=255)
+    conteudo = models.TextField()
+    continente = models.CharField(max_length=60)
+    pais = models.CharField(max_length=120)
+    cidade_destino = models.CharField(max_length=120)
+    origem = models.CharField(max_length=10)
+    destino = models.CharField(max_length=10)
+    classe = models.CharField(max_length=20, choices=CLASSE_CHOICES)
+    programa_fidelidade = models.CharField(max_length=120)
+    companhia_aerea = models.CharField(max_length=120)
+    valor_milhas = models.IntegerField(blank=True, null=True)
+    valor_reais = models.DecimalField(max_digits=10, decimal_places=2, blank=True, null=True)
+    datas_ida = models.JSONField(default=list, blank=True)
+    datas_volta = models.JSONField(default=list, blank=True)
+    ativo = models.BooleanField(default=True)
+    criado_em = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-criado_em"]
+
+    def __str__(self):
+        return f"{self.titulo} ({self.origem} → {self.destino})"

--- a/gestao/models/notificacao_sistema.py
+++ b/gestao/models/notificacao_sistema.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class NotificacaoSistema(models.Model):
+    titulo = models.CharField(max_length=255)
+    mensagem = models.TextField()
+    criado_em = models.DateTimeField(auto_now_add=True)
+    lida = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ["-criado_em"]
+
+    def __str__(self):
+        return self.titulo

--- a/gestao/static/gestao/css/admin-theme.css
+++ b/gestao/static/gestao/css/admin-theme.css
@@ -360,6 +360,162 @@ a:hover {
   font-weight: 700;
 }
 
+.alert-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--heading);
+  font-size: 12px;
+  font-weight: 600;
+  background: #f8fafc;
+  transition: all 0.2s ease;
+}
+
+.chip.is-active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.alert-card-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.alert-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: var(--shadow);
+}
+
+.alert-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.alert-card__header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.alert-card__body p {
+  margin: 0 0 0.4rem;
+  font-size: 12px;
+}
+
+.alert-card__prices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.4rem 0;
+}
+
+.price-tag {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.alert-card__footer {
+  margin-top: auto;
+}
+
+.alert-detail__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.alert-detail__prices {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.alert-detail__dates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.alert-detail__content {
+  margin-bottom: 1rem;
+}
+
+.alert-detail__rich {
+  background: #f8fafc;
+  border-radius: 6px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.date-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.date-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #f1f5f9;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.date-chip.is-removable {
+  cursor: pointer;
+}
+
+.date-chip .remove {
+  font-weight: 700;
+}
+
+.alerta-dates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.alerta-date-column {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .table-wrapper {
   width: 100%;
   overflow-x: auto;

--- a/gestao/static/gestao/js/alertas_detail.js
+++ b/gestao/static/gestao/js/alertas_detail.js
@@ -1,0 +1,18 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const copyButton = document.querySelector("[data-copy-text]");
+  if (!copyButton) {
+    return;
+  }
+  copyButton.addEventListener("click", async () => {
+    const text = copyButton.dataset.copyText || "";
+    try {
+      await navigator.clipboard.writeText(text);
+      copyButton.textContent = "✅ Texto copiado";
+      setTimeout(() => {
+        copyButton.textContent = "📋 Copiar texto completo";
+      }, 2000);
+    } catch (error) {
+      copyButton.textContent = "❌ Falha ao copiar";
+    }
+  });
+});

--- a/gestao/static/gestao/js/alertas_form.js
+++ b/gestao/static/gestao/js/alertas_form.js
@@ -1,0 +1,101 @@
+const dateFormat = "Y-m-d";
+
+const parseValue = (input) => {
+  if (!input || !input.value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(input.value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const formatDate = (dateObj) => dateObj.toISOString().slice(0, 10);
+
+const expandRange = (rangeDates) => {
+  if (!rangeDates || rangeDates.length < 2) {
+    return [];
+  }
+  const [start, end] = rangeDates;
+  const dates = [];
+  const current = new Date(start);
+  while (current <= end) {
+    dates.push(formatDate(current));
+    current.setDate(current.getDate() + 1);
+  }
+  return dates;
+};
+
+const renderChips = (container, dates) => {
+  container.innerHTML = "";
+  if (!dates.length) {
+    const empty = document.createElement("span");
+    empty.className = "muted";
+    empty.textContent = "Nenhuma data selecionada.";
+    container.appendChild(empty);
+    return;
+  }
+  dates.forEach((date) => {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "date-chip is-removable";
+    chip.dataset.dateValue = date;
+    chip.innerHTML = `<span>${date}</span><span class="remove">×</span>`;
+    container.appendChild(chip);
+  });
+};
+
+const setupDateGroup = (groupEl) => {
+  const hiddenInput = groupEl.querySelector("input[type='hidden']");
+  const chipsContainer = groupEl.querySelector("[data-chips]");
+  const calendarInput = groupEl.querySelector("[data-calendar]");
+  const rangeInput = groupEl.querySelector("[data-range]");
+  const confirmButton = groupEl.querySelector("[data-confirm]");
+
+  let selectedDates = parseValue(hiddenInput);
+
+  const syncHidden = () => {
+    hiddenInput.value = JSON.stringify(selectedDates);
+    renderChips(chipsContainer, selectedDates);
+  };
+
+  syncHidden();
+
+  const calendar = flatpickr(calendarInput, {
+    mode: "multiple",
+    dateFormat,
+    allowInput: false,
+  });
+
+  const rangePicker = flatpickr(rangeInput, {
+    mode: "range",
+    dateFormat,
+    allowInput: false,
+  });
+
+  confirmButton.addEventListener("click", () => {
+    const multipleDates = calendar.selectedDates.map(formatDate);
+    const rangeDates = expandRange(rangePicker.selectedDates);
+    const merged = Array.from(new Set([...selectedDates, ...multipleDates, ...rangeDates]));
+    selectedDates = merged.sort();
+    calendar.clear();
+    rangePicker.clear();
+    syncHidden();
+  });
+
+  chipsContainer.addEventListener("click", (event) => {
+    const target = event.target.closest(".date-chip.is-removable");
+    if (!target) {
+      return;
+    }
+    const value = target.dataset.dateValue;
+    selectedDates = selectedDates.filter((item) => item !== value);
+    syncHidden();
+  });
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("[data-date-group]").forEach(setupDateGroup);
+});

--- a/gestao/templates/admin_custom/alertas_confirm_delete.html
+++ b/gestao/templates/admin_custom/alertas_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Excluir alerta{% endblock %}
+{% block header_title %}Alertas de Passagens{% endblock %}
+{% block menu_alertas %}is-active{% endblock %}
+{% block content %}
+<div class="surface-card">
+  <div class="section-heading">
+    <div>
+      <p class="eyebrow">Confirmação</p>
+      <h2 class="section-title">Excluir alerta</h2>
+    </div>
+  </div>
+  <p>Tem certeza que deseja excluir o alerta <strong>{{ alerta.titulo }}</strong>?</p>
+  <form method="post" class="page-actions">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Excluir</button>
+    <a href="{% url 'admin_alertas_passagens' %}" class="btn btn--ghost">Cancelar</a>
+  </form>
+</div>
+{% endblock %}

--- a/gestao/templates/admin_custom/alertas_detail.html
+++ b/gestao/templates/admin_custom/alertas_detail.html
@@ -1,0 +1,87 @@
+{% extends "admin_custom/base_admin.html" %}
+{% load static %}
+{% block title %}Detalhe do alerta{% endblock %}
+{% block header_title %}Alertas de Passagens{% endblock %}
+{% block menu_alertas %}is-active{% endblock %}
+{% block content %}
+<div class="stacked">
+  <section class="surface-card alert-detail">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Detalhe do alerta</p>
+        <h2 class="section-title">{{ alerta.titulo }}</h2>
+        <p class="section-subtitle">{{ alerta.cidade_destino }} - {{ alerta.pais }}</p>
+      </div>
+      <a href="{% url 'alertas_passagens' %}" class="btn btn--ghost">Voltar</a>
+    </div>
+
+    <div class="alert-detail__meta">
+      <div>
+        <p class="muted">Origem → Destino</p>
+        <p><strong>{{ alerta.origem }} → {{ alerta.destino }}</strong></p>
+      </div>
+      <div>
+        <p class="muted">Classe</p>
+        <span class="pill pill-neutral">{{ alerta.get_classe_display }}</span>
+      </div>
+      <div>
+        <p class="muted">Programa de fidelidade</p>
+        <p><strong>{{ alerta.programa_fidelidade }}</strong></p>
+      </div>
+      <div>
+        <p class="muted">Companhia aérea</p>
+        <p><strong>{{ alerta.companhia_aerea }}</strong></p>
+      </div>
+    </div>
+
+    <div class="alert-detail__prices">
+      {% if alerta.valor_milhas %}
+        <span class="price-tag">{{ alerta.valor_milhas }} milhas</span>
+      {% endif %}
+      {% if alerta.valor_reais %}
+        <span class="price-tag">R$ {{ alerta.valor_reais }}</span>
+      {% endif %}
+    </div>
+
+    <div class="alert-detail__dates">
+      <div>
+        <p class="muted">Datas de ida</p>
+        <div class="date-chip-list">
+          {% for data in datas_ida %}
+            <span class="date-chip">{{ data }}</span>
+          {% empty %}
+            <span class="muted">Sem datas cadastradas.</span>
+          {% endfor %}
+        </div>
+      </div>
+      <div>
+        <p class="muted">Datas de volta</p>
+        <div class="date-chip-list">
+          {% for data in datas_volta %}
+            <span class="date-chip">{{ data }}</span>
+          {% empty %}
+            <span class="muted">Sem datas cadastradas.</span>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+
+    <div class="alert-detail__content">
+      <h3 class="section-title">Conteúdo completo</h3>
+      <div class="alert-detail__rich">
+        {{ alerta.conteudo|urlize|linebreaksbr }}
+      </div>
+    </div>
+
+    <div class="page-actions">
+      <button type="button" class="btn btn-secondary" data-copy-text="{{ alerta.conteudo|escapejs }}">📋 Copiar texto completo</button>
+      {% if link_externo %}
+        <a href="{{ link_externo }}" class="btn btn-primary" target="_blank" rel="noopener">🔗 Abrir link externo</a>
+      {% endif %}
+    </div>
+  </section>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script src="{% static 'gestao/js/alertas_detail.js' %}"></script>
+{% endblock %}

--- a/gestao/templates/admin_custom/alertas_form.html
+++ b/gestao/templates/admin_custom/alertas_form.html
@@ -1,0 +1,149 @@
+{% extends "admin_custom/base_admin.html" %}
+{% load static %}
+{% block title %}Alertas de Passagens{% endblock %}
+{% block header_title %}Alertas de Passagens{% endblock %}
+{% block header_subtitle %}<p class="page-subtitle">Cadastro manual de alertas com datas inteligentes.</p>{% endblock %}
+{% block menu_alertas %}is-active{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
+{% endblock %}
+{% block content %}
+<div class="form-wrapper">
+  <form method="post" class="form-shell" data-alerta-form>
+    {% csrf_token %}
+    <div class="form-title">{{ titulo_pagina }}</div>
+
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.titulo.id_for_label }}">{{ form.titulo.label }}</label>
+      {{ form.titulo }}
+    </div>
+    <div class="form-group single">
+      <label class="form-label" for="{{ form.conteudo.id_for_label }}">{{ form.conteudo.label }}</label>
+      {{ form.conteudo }}
+    </div>
+
+    <div class="section-card">
+      <div class="section-card__header">
+        <div>
+          <div class="section-card__title">Destino e rota</div>
+          <p class="section-card__description">Dados para a vitrine de alertas.</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <div>
+          <label class="form-label" for="{{ form.continente.id_for_label }}">{{ form.continente.label }}</label>
+          {{ form.continente }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.pais.id_for_label }}">{{ form.pais.label }}</label>
+          {{ form.pais }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.cidade_destino.id_for_label }}">{{ form.cidade_destino.label }}</label>
+          {{ form.cidade_destino }}
+        </div>
+      </div>
+      <div class="form-group">
+        <div>
+          <label class="form-label" for="{{ form.origem.id_for_label }}">{{ form.origem.label }}</label>
+          {{ form.origem }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.destino.id_for_label }}">{{ form.destino.label }}</label>
+          {{ form.destino }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.classe.id_for_label }}">{{ form.classe.label }}</label>
+          {{ form.classe }}
+        </div>
+      </div>
+    </div>
+
+    <div class="section-card">
+      <div class="section-card__header">
+        <div>
+          <div class="section-card__title">Programa e valores</div>
+          <p class="section-card__description">Informações comerciais e de fidelidade.</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <div>
+          <label class="form-label" for="{{ form.programa_fidelidade.id_for_label }}">{{ form.programa_fidelidade.label }}</label>
+          {{ form.programa_fidelidade }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.companhia_aerea.id_for_label }}">{{ form.companhia_aerea.label }}</label>
+          {{ form.companhia_aerea }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.valor_milhas.id_for_label }}">{{ form.valor_milhas.label }}</label>
+          {{ form.valor_milhas }}
+        </div>
+      </div>
+      <div class="form-group">
+        <div>
+          <label class="form-label" for="{{ form.valor_reais.id_for_label }}">{{ form.valor_reais.label }}</label>
+          {{ form.valor_reais }}
+        </div>
+        <div>
+          <label class="form-label" for="{{ form.ativo.id_for_label }}">{{ form.ativo.label }}</label>
+          {{ form.ativo }}
+        </div>
+      </div>
+    </div>
+
+    <div class="section-card">
+      <div class="section-card__header">
+        <div>
+          <div class="section-card__title">Datas de viagem</div>
+          <p class="section-card__description">Selecione múltiplas datas ou intervalos e confirme.</p>
+        </div>
+      </div>
+      <div class="alerta-dates">
+        <div class="alerta-date-column" data-date-group="ida">
+          <h3 class="section-title">Datas de ida</h3>
+          <div class="form-grid--dates">
+            <div>
+              <label class="form-label">Selecionar datas</label>
+              <input type="text" class="input" data-calendar placeholder="Selecione datas" readonly>
+            </div>
+            <div>
+              <label class="form-label">Selecionar intervalo</label>
+              <input type="text" class="input" data-range placeholder="Selecione um intervalo" readonly>
+            </div>
+          </div>
+          <button type="button" class="btn btn--ghost" data-confirm>Confirmar datas</button>
+          <div class="date-chip-list" data-chips></div>
+          {{ form.datas_ida }}
+        </div>
+        <div class="alerta-date-column" data-date-group="volta">
+          <h3 class="section-title">Datas de volta</h3>
+          <div class="form-grid--dates">
+            <div>
+              <label class="form-label">Selecionar datas</label>
+              <input type="text" class="input" data-calendar placeholder="Selecione datas" readonly>
+            </div>
+            <div>
+              <label class="form-label">Selecionar intervalo</label>
+              <input type="text" class="input" data-range placeholder="Selecione um intervalo" readonly>
+            </div>
+          </div>
+          <button type="button" class="btn btn--ghost" data-confirm>Confirmar datas</button>
+          <div class="date-chip-list" data-chips></div>
+          {{ form.datas_volta }}
+        </div>
+      </div>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="btn">Salvar alerta</button>
+      <a href="{% url 'admin_alertas_passagens' %}" class="btn btn--ghost">Cancelar</a>
+    </div>
+  </form>
+</div>
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="{% static 'gestao/js/alertas_form.js' %}"></script>
+{% endblock %}

--- a/gestao/templates/admin_custom/alertas_list.html
+++ b/gestao/templates/admin_custom/alertas_list.html
@@ -1,0 +1,81 @@
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Alertas de Passagens{% endblock %}
+{% block header_title %}Alertas de Passagens{% endblock %}
+{% block header_subtitle %}<p class="page-subtitle">Gerencie alertas curados para a vitrine interna.</p>{% endblock %}
+{% block menu_alertas %}is-active{% endblock %}
+{% block header_actions %}
+<a href="{% url 'admin_alerta_passagem_novo' %}" class="btn">+ Novo alerta</a>
+{% endblock %}
+{% block content %}
+<div class="stacked">
+  <section class="surface-card filter-panel" data-filters-root>
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Filtros</p>
+        <h2 class="section-title">Buscar alertas</h2>
+      </div>
+      <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
+    </div>
+    <div class="filter-body is-open" data-filter-panel>
+      <form method="get" class="filter-grid">
+        <div class="form-field">
+          <label class="form-label" for="busca">Título, continente, país ou cidade</label>
+          <input type="text" id="busca" name="busca" value="{{ busca }}" placeholder="Buscar..." />
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="btn">Buscar</button>
+          <a href="{% url 'admin_alertas_passagens' %}" class="btn btn--ghost">Limpar</a>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <section class="surface-card">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Alertas</p>
+        <h2 class="section-title">Lista</h2>
+      </div>
+    </div>
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Título</th>
+            <th>Destino</th>
+            <th>Origem → Destino</th>
+            <th>Status</th>
+            <th>Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for alerta in alertas %}
+          <tr>
+            <td>{{ alerta.titulo }}</td>
+            <td>{{ alerta.cidade_destino }} - {{ alerta.pais }}</td>
+            <td>{{ alerta.origem }} → {{ alerta.destino }}</td>
+            <td>
+              {% if alerta.ativo %}
+                <span class="pill pill-success">Ativo</span>
+              {% else %}
+                <span class="pill pill-danger">Inativo</span>
+              {% endif %}
+            </td>
+            <td>
+              <div class="page-actions">
+                <a href="{% url 'admin_alerta_passagem_editar' alerta.id %}" class="btn btn--ghost">Editar</a>
+                <a href="{% url 'admin_alerta_passagem_deletar' alerta.id %}" class="btn btn--ghost">Excluir</a>
+              </div>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="5" class="p-3 text-center text-zinc-400">Nenhum alerta cadastrado.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/gestao/templates/admin_custom/alertas_vitrine.html
+++ b/gestao/templates/admin_custom/alertas_vitrine.html
@@ -1,0 +1,104 @@
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Alertas de Passagens{% endblock %}
+{% block header_title %}Alertas de Passagens{% endblock %}
+{% block header_subtitle %}<p class="page-subtitle">Vitrine interna de oportunidades por destino.</p>{% endblock %}
+{% block menu_alertas %}is-active{% endblock %}
+{% block content %}
+<div class="stacked">
+  <section class="surface-card">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Navegação por destino</p>
+        <h2 class="section-title">Escolha o destino desejado</h2>
+        <p class="section-subtitle">Selecione continente, país e cidade com alertas ativos.</p>
+      </div>
+      <a href="{% url 'alertas_passagens' %}" class="btn btn--ghost">Limpar filtros</a>
+    </div>
+
+    <div class="alert-filter-grid">
+      <div>
+        <p class="eyebrow">1. Continente</p>
+        <div class="chip-grid">
+          {% for continente in continentes %}
+            <a class="chip {% if continente == selected_continente %}is-active{% endif %}" href="?continente={{ continente|urlencode }}">{{ continente }}</a>
+          {% empty %}
+            <span class="muted">Nenhum alerta ativo.</span>
+          {% endfor %}
+        </div>
+      </div>
+      <div>
+        <p class="eyebrow">2. País</p>
+        <div class="chip-grid">
+          {% if selected_continente %}
+            {% for pais in paises %}
+              <a class="chip {% if pais == selected_pais %}is-active{% endif %}" href="?continente={{ selected_continente|urlencode }}&pais={{ pais|urlencode }}">{{ pais }}</a>
+            {% empty %}
+              <span class="muted">Sem países disponíveis.</span>
+            {% endfor %}
+          {% else %}
+            <span class="muted">Selecione um continente.</span>
+          {% endif %}
+        </div>
+      </div>
+      <div>
+        <p class="eyebrow">3. Cidade</p>
+        <div class="chip-grid">
+          {% if selected_pais %}
+            {% for cidade in cidades %}
+              <a class="chip {% if cidade == selected_cidade %}is-active{% endif %}" href="?continente={{ selected_continente|urlencode }}&pais={{ selected_pais|urlencode }}&cidade={{ cidade|urlencode }}">{{ cidade }}</a>
+            {% empty %}
+              <span class="muted">Sem cidades disponíveis.</span>
+            {% endfor %}
+          {% else %}
+            <span class="muted">Selecione um país.</span>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="surface-card">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Alertas</p>
+        <h2 class="section-title">Oportunidades disponíveis</h2>
+      </div>
+    </div>
+    {% if selected_cidade %}
+      <div class="alert-card-grid">
+        {% for alerta in alertas %}
+          <article class="alert-card">
+            <div class="alert-card__header">
+              <div>
+                <h3>{{ alerta.cidade_destino }} - {{ alerta.pais }}</h3>
+                <p class="muted">{{ alerta.origem }} → {{ alerta.destino }}</p>
+              </div>
+              <span class="pill pill-neutral">{{ alerta.get_classe_display }}</span>
+            </div>
+            <div class="alert-card__body">
+              <p><strong>Programa:</strong> {{ alerta.programa_fidelidade }}</p>
+              <p><strong>Companhia:</strong> {{ alerta.companhia_aerea }}</p>
+              <div class="alert-card__prices">
+                {% if alerta.valor_milhas %}
+                  <span class="price-tag">{{ alerta.valor_milhas }} milhas</span>
+                {% endif %}
+                {% if alerta.valor_reais %}
+                  <span class="price-tag">R$ {{ alerta.valor_reais }}</span>
+                {% endif %}
+              </div>
+              <span class="pill pill-danger">Baixa disponibilidade</span>
+            </div>
+            <div class="alert-card__footer">
+              <a href="{% url 'alerta_passagem_detalhe' alerta.id %}" class="btn btn-primary">Ver detalhes</a>
+            </div>
+          </article>
+        {% empty %}
+          <p class="muted">Nenhum alerta encontrado para este destino.</p>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="muted">Selecione a cidade para visualizar os alertas disponíveis.</p>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -38,6 +38,12 @@
                     </svg>
                     <span>Empresas</span>
                 </a>
+                <a class="nav-item {% block menu_alertas %}{% endblock %}" href="{% url 'admin_alertas_passagens' %}">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3v3M12 18v3M4.93 4.93l2.12 2.12M16.83 16.83l2.12 2.12M3 12h3M18 12h3M4.93 19.07l2.12-2.12M16.83 7.17l2.12-2.12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                    </svg>
+                    <span>Alertas de Passagens</span>
+                </a>
             {% else %}
                 <a class="nav-item {% block menu_dashboard %}{% endblock %}" href="{% url 'admin_dashboard' %}">
                     <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -87,6 +93,13 @@
                         <path d="M7 7h10M7 11h10M7 15h6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
                     </svg>
                     <span>Emissões</span>
+                </a>
+
+                <a class="nav-item {% block menu_alertas %}{% endblock %}" href="{% url 'alertas_passagens' %}">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3v3M12 18v3M4.93 4.93l2.12 2.12M16.83 16.83l2.12 2.12M3 12h3M18 12h3M4.93 19.07l2.12-2.12M16.83 7.17l2.12-2.12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                    </svg>
+                    <span>Alertas de Passagens</span>
                 </a>
 
                 <a class="nav-item {% block menu_hoteis %}{% endblock %}" href="{% url 'admin_hoteis' %}">

--- a/gestao/urls_admin.py
+++ b/gestao/urls_admin.py
@@ -55,6 +55,12 @@ from gestao.views import (
     criar_emissor_parceiro,
     editar_emissor_parceiro,
     deletar_emissor_parceiro,
+    admin_alertas_passagens,
+    criar_alerta_passagem,
+    editar_alerta_passagem,
+    deletar_alerta_passagem,
+    alertas_passagens,
+    alerta_passagem_detalhe,
 )
 
 urlpatterns = [
@@ -96,6 +102,12 @@ urlpatterns = [
     path('emissores-parceiros/<int:emissor_id>/deletar/', deletar_emissor_parceiro, name='admin_deletar_emissor_parceiro'),
     path('cotacoes/', admin_cotacoes, name='admin_cotacoes'),
     path('cotacoes/<int:cotacao_id>/deletar/', deletar_cotacao, name='admin_deletar_cotacao'),
+    path('alertas-passagens/', alertas_passagens, name='alertas_passagens'),
+    path('alertas-passagens/<int:alerta_id>/', alerta_passagem_detalhe, name='alerta_passagem_detalhe'),
+    path('alertas-passagens/gerenciar/', admin_alertas_passagens, name='admin_alertas_passagens'),
+    path('alertas-passagens/gerenciar/novo/', criar_alerta_passagem, name='admin_alerta_passagem_novo'),
+    path('alertas-passagens/gerenciar/<int:alerta_id>/editar/', editar_alerta_passagem, name='admin_alerta_passagem_editar'),
+    path('alertas-passagens/gerenciar/<int:alerta_id>/deletar/', deletar_alerta_passagem, name='admin_alerta_passagem_deletar'),
     path('cotacoes-voo/', admin_cotacoes_voo, name='admin_cotacoes_voo'),
     path('cotacoes-voo/calculadora/', calculadora_cotacao, name='admin_calculadora_cotacao'),
     path('cotacoes-voo/nova/', nova_cotacao_voo, name='admin_nova_cotacao_voo'),

--- a/gestao/views/__init__.py
+++ b/gestao/views/__init__.py
@@ -10,3 +10,4 @@ from .dashboard import *
 from .movimentacoes import *
 from .auditoria import *
 from .empresas import *
+from .alertas import *

--- a/gestao/views/alertas.py
+++ b/gestao/views/alertas.py
@@ -1,0 +1,174 @@
+import re
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
+from django.db.models import Q
+
+from ..forms import AlertaViagemForm
+from ..models import AlertaViagem
+from .permissions import require_admin_or_operator
+
+
+def _require_superuser(request):
+    if not request.user.is_superuser:
+        return render(request, "sem_permissao.html")
+    return None
+
+
+def _extract_link(conteudo):
+    if not conteudo:
+        return None
+    match = re.search(r"(https?://\\S+)", conteudo)
+    return match.group(1) if match else None
+
+
+@login_required
+def admin_alertas_passagens(request):
+    if permission_denied := _require_superuser(request):
+        return permission_denied
+    busca = request.GET.get("busca", "").strip()
+    alertas = AlertaViagem.objects.all()
+    if busca:
+        alertas = alertas.filter(
+            Q(titulo__icontains=busca)
+            | Q(continente__icontains=busca)
+            | Q(pais__icontains=busca)
+            | Q(cidade_destino__icontains=busca)
+        )
+    return render(
+        request,
+        "admin_custom/alertas_list.html",
+        {"alertas": alertas, "busca": busca},
+    )
+
+
+@login_required
+def criar_alerta_passagem(request):
+    if permission_denied := _require_superuser(request):
+        return permission_denied
+    if request.method == "POST":
+        form = AlertaViagemForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Alerta criado com sucesso.")
+            return redirect("admin_alertas_passagens")
+    else:
+        form = AlertaViagemForm()
+    return render(
+        request,
+        "admin_custom/alertas_form.html",
+        {"form": form, "titulo_pagina": "Novo alerta"},
+    )
+
+
+@login_required
+def editar_alerta_passagem(request, alerta_id):
+    if permission_denied := _require_superuser(request):
+        return permission_denied
+    alerta = get_object_or_404(AlertaViagem, id=alerta_id)
+    if request.method == "POST":
+        form = AlertaViagemForm(request.POST, instance=alerta)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Alerta atualizado com sucesso.")
+            return redirect("admin_alertas_passagens")
+    else:
+        form = AlertaViagemForm(instance=alerta)
+    return render(
+        request,
+        "admin_custom/alertas_form.html",
+        {"form": form, "titulo_pagina": "Editar alerta"},
+    )
+
+
+@login_required
+def deletar_alerta_passagem(request, alerta_id):
+    if permission_denied := _require_superuser(request):
+        return permission_denied
+    alerta = get_object_or_404(AlertaViagem, id=alerta_id)
+    if request.method == "POST":
+        alerta.delete()
+        messages.success(request, "Alerta removido com sucesso.")
+        return redirect("admin_alertas_passagens")
+    return render(
+        request,
+        "admin_custom/alertas_confirm_delete.html",
+        {"alerta": alerta},
+    )
+
+
+@login_required
+def alertas_passagens(request):
+    if permission_denied := require_admin_or_operator(request):
+        return permission_denied
+    base_qs = AlertaViagem.objects.filter(ativo=True)
+    continentes = list(
+        base_qs.values_list("continente", flat=True)
+        .distinct()
+        .order_by("continente")
+    )
+    selected_continente = request.GET.get("continente") or None
+    if selected_continente not in continentes:
+        selected_continente = None
+    paises = []
+    if selected_continente:
+        paises = list(
+            base_qs.filter(continente=selected_continente)
+            .values_list("pais", flat=True)
+            .distinct()
+            .order_by("pais")
+        )
+    selected_pais = request.GET.get("pais") or None
+    if selected_pais not in paises:
+        selected_pais = None
+    cidades = []
+    if selected_continente and selected_pais:
+        cidades = list(
+            base_qs.filter(continente=selected_continente, pais=selected_pais)
+            .values_list("cidade_destino", flat=True)
+            .distinct()
+            .order_by("cidade_destino")
+        )
+    selected_cidade = request.GET.get("cidade") or None
+    if selected_cidade not in cidades:
+        selected_cidade = None
+    alertas = base_qs
+    if selected_continente:
+        alertas = alertas.filter(continente=selected_continente)
+    if selected_pais:
+        alertas = alertas.filter(pais=selected_pais)
+    if selected_cidade:
+        alertas = alertas.filter(cidade_destino=selected_cidade)
+    else:
+        alertas = alertas.none()
+    return render(
+        request,
+        "admin_custom/alertas_vitrine.html",
+        {
+            "alertas": alertas,
+            "continentes": continentes,
+            "paises": paises,
+            "cidades": cidades,
+            "selected_continente": selected_continente,
+            "selected_pais": selected_pais,
+            "selected_cidade": selected_cidade,
+        },
+    )
+
+
+@login_required
+def alerta_passagem_detalhe(request, alerta_id):
+    if permission_denied := require_admin_or_operator(request):
+        return permission_denied
+    alerta = get_object_or_404(AlertaViagem, id=alerta_id, ativo=True)
+    return render(
+        request,
+        "admin_custom/alertas_detail.html",
+        {
+            "alerta": alerta,
+            "datas_ida": alerta.datas_ida or [],
+            "datas_volta": alerta.datas_volta or [],
+            "link_externo": _extract_link(alerta.conteudo),
+        },
+    )


### PR DESCRIPTION
### Motivation
- Implement an internal "Alertas de Passagens" vitrine to display curated travel opportunities (not booking, not real-time search). 
- Allow only Super Admin to create/edit/activate alerts and make them visible to Empresa/Operador profiles. 
- Provide a simple internal notifications model for future use. 
- Simplify date entry for Super Admin using a lightweight date-picker workflow (multi-select and ranges saved as JSON).

### Description
- Added models `AlertaViagem` and `NotificacaoSistema` and a migration `0030_alerta_viagem_notificacao_sistema.py` to persist alerts and notifications. 
- Implemented `AlertaViagemForm` (with JSON hidden fields for `datas_ida`/`datas_volta`) and server-side validation of date arrays. 
- Added admin views and vitrine views in `gestao/views/alertas.py` with routes registered in `gestao/urls_admin.py` and exported via `gestao/views/__init__.py`. 
- Added templates (`alertas_list.html`, `alertas_form.html`, `alertas_confirm_delete.html`, `alertas_vitrine.html`, `alertas_detail.html`), JS assets (`alertas_form.js` using `flatpickr` for multi/date-range selection and `alertas_detail.js` for copy-to-clipboard), and CSS updates in `gestao/static/gestao/css/admin-theme.css` for styling cards/chips. 

### Testing
- Ran `python manage.py check` which completed with no system-check issues. 
- Ran `python manage.py migrate` and applied the new migration `0030_alerta_viagem_notificacao_sistema` successfully. 
- Created a sample Super Admin user and seeded an `AlertaViagem` instance via the Django shell to verify model persistence (succeeded after migrations). 
- Attempted an automated Playwright screenshot to exercise the UI, but the headless browser failed to start in the environment (Playwright/Chromium error), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae9671288832780433f45c8d52d69)