### PR TITLE
Admin UI overhaul: new Home, Dashboard templates, context and client filters

### DIFF
--- a/gestao/services/dashboard.py
+++ b/gestao/services/dashboard.py
@@ -598,6 +598,13 @@ def _build_management_dashboard(emissoes_qs, request, *, empresa=None):
         "end_date": end_date.isoformat(),
         "previous_period_label": f"{prev_start.strftime('%d/%m')} a {prev_end.strftime('%d/%m')}",
         "kpis": kpis,
+        "summary": {
+            "total_emissoes": _format_number(emissions_count),
+            "receita_total": _format_money(revenue),
+            "lucro_total": _format_money(profit),
+            "milhas_utilizadas": _format_number(miles),
+            "total_taxas": _format_money(fees),
+        },
         "timeline_series": timeline_series,
         "cost_vs_sale": cost_vs_sale,
         "best_programs": best_programs,

--- a/gestao/templates/admin_custom/base_admin.html
+++ b/gestao/templates/admin_custom/base_admin.html
@@ -1,274 +1,89 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-br" class="h-full bg-gray-900">
 <head>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
-    <title>{% block title %}Administração{% endblock %} - Gestão de Pontos</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
+    <title>{% block title %}Administração{% endblock %} - Gestão de Pontos</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = { theme: { extend: { colors: { gray: { 750: '#2d3748' } }, fontFamily: { sans: ['Inter', 'sans-serif'] } } } }
+    </script>
     <link rel="stylesheet" href="{% static 'gestao/css/base/variables.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/css/layout.css' %}">
     <link rel="stylesheet" href="{% static 'painel_cliente/css/components/buttons.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/formulario_base_gestao.css' %}">
     <link rel="stylesheet" href="{% static 'gestao/css/admin-theme.css' %}">
-
     {% block extra_head %}{% endblock %}
 </head>
-
-<body>
-<div class="app-shell">
-    <div class="sidebar-overlay" data-sidebar-overlay></div>
-
-    <aside class="sidebar" data-sidebar>
-        <div class="sidebar-header">
-            <a class="sidebar-brand" href="{% url 'admin_dashboard' %}">
-                <div class="sidebar-logo">✈️</div>
-                <span class="sidebar-title">NCfly</span>
+<body class="h-full bg-gray-900 font-sans text-white antialiased">
+<div class="flex h-screen bg-gray-900">
+    <aside class="hidden h-screen w-64 flex-shrink-0 border-r border-gray-800 bg-gray-950 lg:flex lg:flex-col">
+        <div class="border-b border-gray-800 p-6">
+            <a href="{% url 'admin_dashboard' %}" class="flex items-center gap-3">
+                <div class="h-8 w-8 rounded bg-gradient-to-br from-blue-500 to-purple-600"></div>
+                <span class="text-xl font-semibold text-white">NC Fly</span>
             </a>
-            <button class="icon-button sidebar-close" type="button" aria-label="Fechar menu" data-sidebar-close>
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M6 6l12 12M18 6l-12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                </svg>
-            </button>
         </div>
-        <nav class="sidebar-nav">
+        <nav class="flex-1 overflow-y-auto py-4">
             {% if request.user.is_superuser %}
-                <a class="nav-item {% if menu_ativo == 'empresas' %}is-active{% endif %}" href="{% url 'admin_empresas' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 10h18v11H3z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M7 10V3h10v7" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Empresas</span>
-                </a>
-                <a class="nav-item {% if menu_ativo == 'alertas' %}is-active{% endif %}" href="{% url 'admin_alertas_passagens' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M12 3v3M12 18v3M4.93 4.93l2.12 2.12M16.83 16.83l2.12 2.12M3 12h3M18 12h3M4.93 19.07l2.12-2.12M16.83 7.17l2.12-2.12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Alertas de Passagens</span>
-                </a>
+                <a href="{% url 'admin_empresas' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'empresas' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Empresas</span></a>
+                <a href="{% url 'admin_alertas_passagens' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'alertas' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Alertas de Passagens</span></a>
             {% else %}
-                <a class="nav-item {% if menu_ativo == 'dashboard' %}is-active{% endif %}" href="{% url 'admin_dashboard' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 12 12 3l9 9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M9 21V9h6v12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Dashboard</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'clientes' %}is-active{% endif %}" href="{% url 'admin_clientes' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <circle cx="8.5" cy="7" r="4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M20 8v6M23 11h-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Clientes</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'contas' %}is-active{% endif %}" href="{% url 'admin_contas' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M4 4h16v16H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M8 2v4M16 2v4M4 10h16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Contas Fidelidade</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'contas_adm' %}is-active{% endif %}" href="{% url 'admin_contas_administradas' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 7h18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M3 12h18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M3 17h18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Contas Administradas</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'cotacoes' %}is-active{% endif %}" href="{% url 'admin_cotacoes_voo' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M2 12h20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M5 12l6-6M5 12l6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Cotações</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'emissoes' %}is-active{% endif %}" href="{% url 'admin_emissoes' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M4 4h16v16H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M7 7h10M7 11h10M7 15h6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Emissões</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'alertas' %}is-active{% endif %}" href="{% url 'alertas_passagens' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M12 3v3M12 18v3M4.93 4.93l2.12 2.12M16.83 16.83l2.12 2.12M3 12h3M18 12h3M4.93 19.07l2.12-2.12M16.83 7.17l2.12-2.12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Alertas de Passagens</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'hoteis' %}is-active{% endif %}" href="{% url 'admin_hoteis' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M3 20h18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M4 20V7a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v13" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M8 14h.01M12 14h.01M16 14h.01" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Hotéis</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'calculadora' %}is-active{% endif %}" href="{% url 'admin_calculadora_cotacao' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M6 4h12v16H6z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M8 8h8M8 12h2M14 12h2M8 16h2M14 16h2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Calculadora</span>
-                </a>
-
-                <a class="nav-item {% if menu_ativo == 'emissores' %}is-active{% endif %}" href="{% url 'admin_emissores_parceiros' %}">
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M4 4h16v6H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M4 14h10v6H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        <path d="M18 14v6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <span>Emissores Parceiros</span>
-                </a>
-
-                <details class="nav-group" {% if menu_ativo == 'aeroportos' or menu_ativo == 'companhias' or menu_ativo == 'programas' %}open{% endif %}>
-                    <summary class="nav-item nav-item--summary">
-                        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M4 4h16v16H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            <path d="M8 12h8M12 8v8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        </svg>
-                        <span>Dados Complementares</span>
-                    </summary>
-                    <div class="nav-subitems">
-                        <a class="nav-item {% if menu_ativo == 'aeroportos' %}is-active{% endif %}" href="{% url 'admin_aeroportos' %}">
-                            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M2 12h20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                                <path d="M6 16l6-6 6 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            </svg>
-                            <span>Aeroporto</span>
-                        </a>
-                        <a class="nav-item {% if menu_ativo == 'companhias' %}is-active{% endif %}" href="{% url 'admin_companhias' %}">
-                            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M2 8l10 4 10-4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                                <path d="M2 12l10 4 10-4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            </svg>
-                            <span>Companhia Aérea</span>
-                        </a>
-                        <a class="nav-item {% if menu_ativo == 'programas' %}is-active{% endif %}" href="{% url 'admin_programas' %}">
-                            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M4 4h16v6H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                                <path d="M4 14h16v6H4z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            </svg>
-                            <span>Programa de Pontos</span>
-                        </a>
+                <a href="{% url 'admin_dashboard' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'home' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Home</span></a>
+                <a href="{% url 'admin_dashboard_analytics' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'dashboard' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Dashboard</span></a>
+                <a href="{% url 'admin_clientes' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'clientes' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Clientes</span></a>
+                <a href="{% url 'admin_contas' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'contas' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Contas Fidelidade</span></a>
+                <a href="{% url 'admin_contas_administradas' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'contas_adm' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Contas Administrativas</span></a>
+                <a href="{% url 'admin_cotacoes_voo' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'cotacoes' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Cotações</span></a>
+                <a href="{% url 'admin_emissoes' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'emissoes' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Emissões</span></a>
+                <a href="{% url 'alertas_passagens' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'alertas' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Avulso de Passagens</span></a>
+                <a href="{% url 'admin_hoteis' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'hoteis' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Hotéis</span></a>
+                <a href="{% url 'admin_calculadora_cotacao' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'calculadora' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Calculadora</span></a>
+                <a href="{% url 'admin_emissores_parceiros' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'emissores' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Rotas Compartilhadas</span></a>
+                <details class="{% if menu_ativo == 'aeroportos' or menu_ativo == 'companhias' or menu_ativo == 'programas' %}open{% endif %}">
+                    <summary class="flex cursor-pointer items-center justify-between px-6 py-3 text-sm text-gray-400 hover:bg-gray-900"><span>Operações</span></summary>
+                    <div class="pb-2">
+                        <a href="{% url 'admin_aeroportos' %}" class="flex items-center justify-between px-10 py-2 text-sm {% if menu_ativo == 'aeroportos' %}text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Aeroportos</span></a>
+                        <a href="{% url 'admin_companhias' %}" class="flex items-center justify-between px-10 py-2 text-sm {% if menu_ativo == 'companhias' %}text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Companhias</span></a>
+                        <a href="{% url 'admin_programas' %}" class="flex items-center justify-between px-10 py-2 text-sm {% if menu_ativo == 'programas' %}text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Programas</span></a>
                     </div>
                 </details>
-            {% endif %}
-
-            {% if not request.user.is_superuser %}
-            <a class="nav-item {% if menu_ativo == 'auditoria' %}is-active{% endif %}" href="{% url 'admin_auditoria' %}">
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M12 6v6l4 2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                </svg>
-                <span>Auditoria</span>
-            </a>
-            {% endif %}
-
-            {% with perfil=request.user.cliente_gestao.perfil %}
-                {% if perfil == "admin" or request.user.is_superuser %}
-                    <a class="nav-item {% if menu_ativo == 'usuarios' %}is-active{% endif %}" href="{% url 'user_list' %}">
-                        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            <circle cx="8.5" cy="7" r="4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        </svg>
-                        <span>Usuários Administradores</span>
-                    </a>
-                    <a class="nav-item {% if menu_ativo == 'operadores' %}is-active{% endif %}" href="{% url 'operator_list' %}">
-                        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M12 6v6l4 2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                            <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                        </svg>
-                        <span>Operadores</span>
-                    </a>
-                {% endif %}
-            {% endwith %}
-
-            <a class="nav-item" href="{% url 'logout' %}">
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    <path d="M10 17l5-5-5-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    <path d="M15 12H3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                </svg>
-                <span>Sair</span>
-            </a>
-        </nav>
-    </aside>
-
-    <div class="app-shell__content">
-        <header class="app-header">
-            <div class="app-header__left">
-                <button class="icon-button menu-button" type="button" aria-label="Abrir menu" data-sidebar-open>
-                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                </button>
-                <div>
-                    <h2 class="app-header__title">{% block page_title %}Gestão Admin{% endblock %}</h2>
-                    {% block app_header_subtitle %}{% endblock %}
-                </div>
-            </div>
-            <div class="app-header__actions">
-                <div class="header-search">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-                    </svg>
-                    <input type="text" placeholder="Buscar..." aria-label="Buscar" />
-                </div>
-                <button class="notification-btn" type="button" aria-label="Notificações">
-                    🔔
-                    <span class="badge info">3</span>
-                </button>
-                <span class="user-name">{{ request.user.get_full_name|default:request.user.username }}</span>
-                <button class="icon-button" type="button" data-theme-toggle aria-label="Alternar modo escuro">🌙</button>
-            </div>
-        </header>
-
-        <main class="app-main fpp-main">
-            <div class="fpp-container">
-                <div class="page-shell">
-                    <div class="page-header fpp-header">
-                        <div class="page-header__titles">
-                            <h1 class="page-title">{% block header_title %}Painel Administrativo{% endblock %}</h1>
-                            {% block header_subtitle %}{% endblock %}
-                        </div>
-                        <div class="page-actions fpp-actions">
-                            {% block header_actions %}{% endblock %}
-                        </div>
-                    </div>
-
-                    {% if messages %}
-                    <div class="message-stack">
-                        {% for message in messages %}
-                        <div class="alert {% if 'success' in message.tags %}alert-success{% else %}alert-danger{% endif %}">
-                            {{ message }}
-                        </div>
-                        {% endfor %}
-                    </div>
+                <a href="{% url 'admin_auditoria' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'auditoria' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Auditorias</span></a>
+                {% with perfil=request.user.cliente_gestao.perfil %}
+                    {% if perfil == 'admin' or request.user.is_superuser %}
+                        <a href="{% url 'user_list' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'usuarios' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Usuários Administrativos</span></a>
+                        <a href="{% url 'operator_list' %}" class="flex items-center justify-between px-6 py-3 text-sm {% if menu_ativo == 'operadores' %}border-l-4 border-blue-500 bg-blue-600 text-white{% else %}text-gray-400 hover:bg-gray-900{% endif %}"><span>Operadores</span></a>
                     {% endif %}
-
-                    {% block content %}{% endblock %}
+                {% endwith %}
+            {% endif %}
+        </nav>
+        <div class="border-t border-gray-800 p-4"><a href="{% url 'logout' %}" class="flex items-center justify-between rounded px-4 py-3 text-sm text-gray-400 hover:bg-gray-900"><span>Logout</span></a></div>
+    </aside>
+    <div class="flex min-w-0 flex-1 flex-col">
+        <header class="border-b border-gray-700 bg-gray-800 px-6 py-4">
+            <div class="flex items-center justify-between gap-4">
+                <div>
+                    <h1 class="text-2xl font-semibold text-white">{% block page_title %}{% block header_title %}Gestão Admin{% endblock %}{% endblock %}</h1>
+                    <div class="text-sm text-gray-400">{% block app_header_subtitle %}{% block header_subtitle %}<span>Painel de gestão de milhas.</span>{% endblock %}{% endblock %}</div>
+                </div>
+                <div class="flex items-center gap-4">
+                    <div class="hidden flex-wrap items-center gap-2 lg:flex">{% block header_actions %}{% endblock %}</div>
+                    <button type="button" class="relative flex h-10 w-10 items-center justify-center rounded-full border border-gray-700 bg-gray-900 text-gray-400"><span>🔔</span><span class="absolute -right-1 -top-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1 text-xs font-semibold text-white">3</span></button>
+                    <div class="h-10 w-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-600"></div>
+                    <div class="hidden text-sm md:block"><div class="font-medium text-white">{{ request.user.get_full_name|default:request.user.username }}</div><div class="text-gray-400">{% if request.user.is_superuser %}Superusuário{% else %}Operação{% endif %}</div></div>
                 </div>
             </div>
-        </main>
+            <div class="mt-4 flex flex-wrap gap-2 lg:hidden">{% block mobile_header_actions %}{% endblock %}</div>
+        </header>
+        <main class="min-h-0 flex-1 overflow-y-auto bg-gray-900"><div class="mx-auto w-full max-w-[1600px] px-6 py-6">{% if messages %}<div class="mb-6 space-y-3">{% for message in messages %}<div class="rounded border border-gray-700 bg-gray-800 px-4 py-3 text-sm text-gray-200">{{ message }}</div>{% endfor %}</div>{% endif %}{% block content %}{% endblock %}</div></main>
     </div>
 </div>
-
-{% block extra_body %}{% endblock %}
-
 <script src="{% static 'gestao/js/forms.js' %}" defer></script>
 <script type="module" src="{% static 'painel_cliente/js/app.js' %}" defer></script>
-{% block extra_js %}{% endblock %}
-
+{% block extra_body %}{% endblock %}
 </body>
 </html>

--- a/gestao/templates/admin_custom/clientes.html
+++ b/gestao/templates/admin_custom/clientes.html
@@ -1,100 +1,42 @@
 {% extends "admin_custom/base_admin.html" %}
-{% load static %}
 {% block title %}Clientes{% endblock %}
-{% block header_title %}Clientes{% endblock %}
-{% block header_subtitle %}<p class="page-subtitle">Cadastre, pesquise e acompanhe clientes com status e ações consistentes.</p>{% endblock %}
+{% block header_title %}Gestão de Clientes{% endblock %}
+{% block header_subtitle %}<span>Base integrada de clientes com filtros, status, ações e paginação reais.</span>{% endblock %}
 {% block header_actions %}
-<a href="{% url 'admin_novo_cliente' %}" class="btn">+ Novo Cliente</a>
+<a href="{% url 'admin_novo_cliente' %}" class="rounded bg-blue-600 px-4 py-2 text-sm text-white">Novo Cliente</a>
 {% endblock %}
 
 {% block content %}
-<div class="stacked">
-    <section class="surface-card filter-panel" data-filters-root>
-        <div class="section-heading">
-            <div>
-                <p class="eyebrow">Filtros</p>
-                <h2 class="section-title">Buscar clientes</h2>
-            </div>
-            <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
-        </div>
-        <div class="filter-body is-open" data-filter-panel>
-            <form method="get" class="filter-grid">
-                <div class="form-field">
-                    <label class="form-label" for="busca">Nome ou usuário</label>
-                    <input
-                        type="text"
-                        id="busca"
-                        name="busca"
-                        value="{{ busca }}"
-                        placeholder="Buscar..."
-                    />
-                </div>
-                <div class="form-actions">
-                    <button type="submit" class="btn">Buscar</button>
-                    <a href="{% url 'admin_clientes' %}" class="btn btn--ghost">Limpar</a>
-                </div>
-            </form>
-        </div>
+<div class="space-y-6 py-2">
+    <section class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <article class="flex justify-between rounded border border-gray-700 bg-gray-800 p-6"><div><p class="text-sm uppercase text-gray-400">Total de clientes</p><p class="mt-3 text-3xl font-semibold text-white">{{ total_clientes }}</p></div><div class="h-12 w-12 rounded-lg bg-blue-500/10"></div></article>
+        <article class="flex justify-between rounded border border-gray-700 bg-gray-800 p-6"><div><p class="text-sm uppercase text-gray-400">Registros na página</p><p class="mt-3 text-3xl font-semibold text-white">{{ page_obj.object_list|length }}</p></div><div class="h-12 w-12 rounded-lg bg-green-500/10"></div></article>
+        <article class="flex justify-between rounded border border-gray-700 bg-gray-800 p-6"><div><p class="text-sm uppercase text-gray-400">Página atual</p><p class="mt-3 text-3xl font-semibold text-white">{{ page_obj.number }}</p></div><div class="h-12 w-12 rounded-lg bg-yellow-500/10"></div></article>
+        <article class="flex justify-between rounded border border-gray-700 bg-gray-800 p-6"><div><p class="text-sm uppercase text-gray-400">Total de páginas</p><p class="mt-3 text-3xl font-semibold text-white">{{ page_obj.paginator.num_pages }}</p></div><div class="h-12 w-12 rounded-lg bg-purple-500/10"></div></article>
     </section>
 
-    <section class="surface-card">
-        <div class="section-heading">
-            <div>
-                <p class="eyebrow">Clientes</p>
-                <h2 class="section-title">Lista de clientes</h2>
-                <p class="section-subtitle">Status e ações alinhados em todas as telas.</p>
-            </div>
-            <div class="muted">Total: {{ total_clientes }}</div>
-        </div>
-        <div class="table-wrapper">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Nome</th>
-                        <th class="hidden md:table-cell">Usuário</th>
-                        <th>Status</th>
-                        <th>Ações</th>
-                    </tr>
-                </thead>
-                <tbody>
+    <section class="rounded border border-gray-700 bg-gray-800 p-6">
+        <form method="get" class="flex flex-col gap-4 lg:flex-row lg:items-end">
+            <div class="flex-1"><label class="mb-2 block text-sm text-gray-400" for="busca">Busca</label><input id="busca" type="text" name="busca" value="{{ busca }}" placeholder="Buscar cliente por nome ou usuário" class="w-full rounded border border-gray-700 bg-gray-900 p-3 text-white placeholder:text-gray-400"></div>
+            <div class="w-full lg:w-56"><label class="mb-2 block text-sm text-gray-400" for="status">Status</label><select id="status" name="status" class="w-full rounded border border-gray-700 bg-gray-900 p-3 text-white"><option value="">Todos</option><option value="ativo" {% if status == 'ativo' %}selected{% endif %}>Ativo</option><option value="inativo" {% if status == 'inativo' %}selected{% endif %}>Inativo</option></select></div>
+            <button type="submit" class="rounded bg-blue-600 px-6 py-3 text-white hover:bg-blue-700">Filtrar</button>
+            <a href="{% url 'admin_clientes' %}" class="rounded border border-gray-700 bg-gray-900 px-6 py-3 text-center text-gray-400">Limpar</a>
+        </form>
+    </section>
+
+    <section class="overflow-hidden rounded border border-gray-700 bg-gray-800">
+        <div class="flex items-center justify-between gap-3 border-b border-gray-700 px-6 py-4"><h2 class="text-lg font-semibold text-white">Clientes cadastrados</h2><span class="text-sm text-gray-400">{{ total_clientes }} registros</span></div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-700">
+                <thead class="bg-gray-900 text-xs uppercase text-gray-300"><tr><th class="px-4 py-3 text-left">Nome</th><th class="px-4 py-3 text-left">Usuário</th><th class="px-4 py-3 text-left">Status</th><th class="px-4 py-3 text-left">Ações</th></tr></thead>
+                <tbody class="divide-y divide-gray-700">
                     {% for cliente in page_obj %}
-                    <tr>
-                        <td>{{ cliente.usuario.first_name|default:cliente.usuario.username }}</td>
-                        <td class="hidden md:table-cell">{{ cliente.usuario.username }}</td>
-                        <td>
-                            {% if cliente.ativo %}
-                                <span class="pill pill-success">Ativo</span>
-                            {% else %}
-                                <span class="pill pill-danger">Inativo</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <details class="dropdown">
-                                <summary class="btn btn-icon" aria-label="Ações do cliente">⋮</summary>
-                                <div class="dropdown-panel">
-                                    <a class="" href="{% url 'admin_visualizar_cliente' cliente.id %}">👁️ Ver</a>
-                                    <a class="" href="{% url 'admin_editar_cliente' cliente.id %}">✏️ Editar</a>
-                                </div>
-                            </details>
-                        </td>
-                    </tr>
-                    {% empty %}
-                    <tr><td colspan="4">Nenhum cliente encontrado.</td></tr>
-                    {% endfor %}
+                    <tr class="hover:bg-gray-750"><td class="px-4 py-3 text-gray-200">{{ cliente.usuario.get_full_name|default:cliente.usuario.username }}</td><td class="px-4 py-3 text-gray-200">{{ cliente.usuario.username }}</td><td class="px-4 py-3 text-gray-200">{% if cliente.ativo %}<span class="inline-flex rounded-full border border-green-500/20 bg-green-500/10 px-3 py-1 text-xs text-green-500">Ativo</span>{% else %}<span class="inline-flex rounded-full border border-red-500/20 bg-red-500/10 px-3 py-1 text-xs text-red-500">Inativo</span>{% endif %}</td><td class="px-4 py-3 text-gray-200"><div class="flex flex-wrap gap-2"><a href="{% url 'admin_visualizar_cliente' cliente.id %}" class="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white">Ver</a><a href="{% url 'admin_editar_cliente' cliente.id %}" class="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white">Editar</a></div></td></tr>
+                    {% empty %}<tr class="hover:bg-gray-750"><td colspan="4" class="px-4 py-3 text-gray-200">Nenhum cliente encontrado.</td></tr>{% endfor %}
                 </tbody>
             </table>
         </div>
-        <div class="table-foot">
-            <div>Mostrando página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}</div>
-            <div class="page-actions">
-                {% if page_obj.has_previous %}
-                    <a class="btn btn--ghost" href="?page={{ page_obj.previous_page_number }}&busca={{ busca }}">Anterior</a>
-                {% endif %}
-                {% if page_obj.has_next %}
-                    <a class="btn btn--ghost" href="?page={{ page_obj.next_page_number }}&busca={{ busca }}">Próxima</a>
-                {% endif %}
-            </div>
-        </div>
+        <div class="flex flex-col gap-4 border-t border-gray-700 px-6 py-4 text-sm text-gray-400 sm:flex-row sm:items-center sm:justify-between"><span>Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}</span><div class="flex flex-wrap gap-2">{% if page_obj.has_previous %}<a class="rounded border border-gray-700 bg-gray-900 px-4 py-2 text-white" href="?page={{ page_obj.previous_page_number }}&busca={{ busca }}&status={{ status }}">Anterior</a>{% endif %}{% if page_obj.has_next %}<a class="rounded border border-gray-700 bg-gray-900 px-4 py-2 text-white" href="?page={{ page_obj.next_page_number }}&busca={{ busca }}&status={{ status }}">Próxima</a>{% endif %}</div></div>
     </section>
 </div>
 {% endblock %}

--- a/gestao/templates/admin_custom/dashboard.html
+++ b/gestao/templates/admin_custom/dashboard.html
@@ -1,324 +1,224 @@
 {% extends "admin_custom/base_admin.html" %}
-{% load static %}
-
 {% block title %}Dashboard{% endblock %}
-{% block header_title %}Dashboard Administrativo{% endblock %}
-{% block header_subtitle %}<p class="page-subtitle">Visão consolidada dos clientes, emissões e reservas com hierarquia clara de informações.</p>{% endblock %}
+{% block header_title %}Dashboard de Milhas{% endblock %}
+{% block header_subtitle %}<span>Visão consolidada da operação com dados reais da gestão.</span>{% endblock %}
 {% block header_actions %}
-<a id="novoClienteBtn" href="{% url 'admin_novo_cliente' %}" class="btn btn--outline">+ Novo Cliente</a>
-<a id="novaEmissaoBtn" href="{% url 'admin_nova_emissao' %}{% if selected_cliente %}?cliente_id={{ selected_cliente.id }}{% endif %}" class="btn">+ Nova Emissão</a>
+<a href="{% url 'admin_novo_cliente' %}" class="rounded bg-gray-900 px-4 py-2 text-sm text-white border border-gray-700">Novo Cliente</a>
+<a href="{% url 'admin_nova_emissao' %}" class="rounded bg-blue-600 px-4 py-2 text-sm text-white">Nova Emissão</a>
 {% endblock %}
 
 {% block content %}
-<div class="stacked">
-  <section class="surface-card filter-panel" data-filters-root>
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Filtro principal</p>
-        <p class="section-title">Escolha o tipo de visão para ajustar os indicadores</p>
+<div class="space-y-6 py-2">
+  <section class="rounded border border-gray-700 bg-gray-800 p-6">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div class="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div><p class="mb-2 text-sm text-gray-400">Período</p><div class="rounded border border-gray-700 bg-gray-900 p-3 text-sm text-gray-200">{{ management_dashboard.start_date }} até {{ management_dashboard.end_date }}</div></div>
+        <div><p class="mb-2 text-sm text-gray-400">Clientes</p><div class="flex flex-wrap gap-2">{% for item in management_dashboard.filter_options.clientes|slice:":4" %}<a href="?{{ item.query }}" class="rounded border px-3 py-2 text-xs {% if item.selected %}border-blue-500 bg-blue-600 text-white{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %}">{{ item.label }}</a>{% empty %}<span class="text-sm text-gray-400">Sem opções</span>{% endfor %}</div></div>
+        <div><p class="mb-2 text-sm text-gray-400">Emissores</p><div class="flex flex-wrap gap-2">{% for item in management_dashboard.filter_options.emissores|slice:":4" %}<a href="?{{ item.query }}" class="rounded border px-3 py-2 text-xs {% if item.selected %}border-blue-500 bg-blue-600 text-white{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %}">{{ item.label }}</a>{% empty %}<span class="text-sm text-gray-400">Sem opções</span>{% endfor %}</div></div>
+        <div><p class="mb-2 text-sm text-gray-400">Companhias / Programas</p><div class="flex flex-wrap gap-2">{% for item in management_dashboard.filter_options.companhias|slice:":2" %}<a href="?{{ item.query }}" class="rounded border px-3 py-2 text-xs {% if item.selected %}border-blue-500 bg-blue-600 text-white{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %}">{{ item.label }}</a>{% endfor %}{% for item in management_dashboard.filter_options.programas|slice:":2" %}<a href="?{{ item.query }}" class="rounded border px-3 py-2 text-xs {% if item.selected %}border-blue-500 bg-blue-600 text-white{% else %}border-gray-700 bg-gray-900 text-gray-400{% endif %}">{{ item.label }}</a>{% endfor %}</div></div>
       </div>
-      <button class="btn btn--ghost filter-toggle" type="button" data-filter-toggle aria-expanded="true">Mostrar filtros</button>
-    </div>
-    <div class="filter-body is-open" data-filter-panel>
-      <div class="filter-grid">
-        <div class="form-field">
-          <label class="form-label" for="viewSelect">Tipo de visão</label>
-          <select id="viewSelect">
-            <option value="clientes" {% if view_type == "clientes" %}selected{% endif %}>Clientes</option>
-            <option value="contas" {% if view_type == "contas" %}selected{% endif %}>Contas administradas</option>
-            <option value="parceiros" {% if view_type == "parceiros" %}selected{% endif %}>Emissores parceiros</option>
-          </select>
-        </div>
-        <div class="form-field" data-filter-type="clientes">
-          <label class="form-label" for="clienteSelect">Cliente</label>
-          <select id="clienteSelect">
-            <option value="">Selecionar Cliente</option>
-            {% for c in clientes %}
-              <option value="{{ c.id }}" {% if selected_cliente and c.id == selected_cliente.id %}selected{% endif %}>{{ c }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field" data-filter-type="contas">
-          <label class="form-label" for="contaSelect">Conta administrada</label>
-          <select id="contaSelect">
-            <option value="">Selecionar Conta</option>
-            {% for conta in contas_administradas %}
-              <option value="{{ conta.id }}" {% if selected_conta and conta.id == selected_conta.id %}selected{% endif %}>{{ conta.nome }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field" data-filter-type="parceiros">
-          <label class="form-label" for="emissorSelect">Emissor parceiro</label>
-          <select id="emissorSelect">
-            <option value="">Selecionar Emissor</option>
-            {% for emissor in emissores_parceiros %}
-              <option value="{{ emissor.id }}" {% if selected_emissor and emissor.id == selected_emissor.id %}selected{% endif %}>{{ emissor.nome }}</option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-      <div class="filter-actions">
-        <span class="muted text-sm">Filtre para enxergar cartões e relatórios com o contexto correto.</span>
+      <div class="flex flex-wrap gap-2">
+        <a href="?{{ management_dashboard.clear_filters_query }}" class="rounded border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-gray-400">Limpar filtros</a>
+        <a href="?{{ management_dashboard.previous_period_query }}" class="rounded border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-white">Período anterior</a>
       </div>
     </div>
   </section>
 
-  <section class="surface-card stacked">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Indicadores</p>
-        <h2 class="section-title">Resumo rápido</h2>
-      </div>
-    </div>
-    {% if view_type == "parceiros" %}
-    {% if total_emissoes %}
-    <div class="stat-grid stats-grid">
-      <div class="stat-card primary">
-        <p class="stat-label">✈️ Total de Emissões</p>
-        <p class="stat-value">{{ total_emissoes }}</p>
-        <p class="stat-meta">Emissões vinculadas ao emissor selecionado</p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">🧾 Total de milhas emitidas</p>
-        <p class="stat-value">{{ parceiros.milhas }}</p>
-        <p class="stat-meta">Milhas usadas nas emissões do parceiro</p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">💸 Valor pago ao parceiro</p>
-        <p class="stat-value">R$ {{ parceiros.valor_pago|floatformat:2 }}</p>
-        <p class="stat-meta">Somatório pago ao parceiro</p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">💰 Lucro total</p>
-        <p class="stat-value">R$ {{ parceiros.lucro|floatformat:2 }}</p>
-        <p class="stat-meta">Lucro consolidado das emissões</p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">📈 Valor médio do milheiro</p>
-        <p class="stat-value">R$ {{ parceiros.valor_medio_milheiro|floatformat:2 }}</p>
-        <p class="stat-meta">Média ponderada por milhas emitidas</p>
-      </div>
-    </div>
-    {% else %}
-      <p class="muted">Nenhuma emissão encontrada para o filtro selecionado.</p>
-    {% endif %}
-    {% else %}
-    <div class="stat-grid stats-grid">
-      <div class="stat-card primary">
-        <p class="stat-label">
-          {% if view_type == "contas" %}🏢 Total de Contas{% else %}👥 Total de Clientes{% endif %}
-        </p>
-        <p class="stat-value">{{ total_titulares }}</p>
-        <p class="stat-meta">
-          {% if view_type == "contas" %}Contas administradas ativas{% else %}Base ativa de clientes acompanhados{% endif %}
-        </p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">✈️ Total de Emissões</p>
-        <p class="stat-value">{{ total_emissoes }}</p>
-        <p class="stat-meta">Passagens emitidas em todos os programas</p>
-      </div>
-      <div class="stat-card">
-        <p class="stat-label">💰 Total Economizado</p>
-        <p class="stat-value">R$ {{ total_economizado|floatformat:2 }}</p>
-        <p class="stat-meta">Economia acumulada em emissões e reservas</p>
-      </div>
-    </div>
-    {% endif %}
+  <section class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Contas admin.</p><p class="mt-3 text-3xl font-semibold text-white">{{ home_counts.contas_administrativas_ativas|default:'—' }}</p></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Emissões</p><p class="mt-3 text-3xl font-semibold text-white">{{ management_dashboard.summary.total_emissoes }}</p></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Contas fidelidade</p><p class="mt-3 text-3xl font-semibold text-white">{{ home_counts.contas_fidelidade|default:'—' }}</p></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Clientes</p><p class="mt-3 text-3xl font-semibold text-white">{{ home_counts.clientes_ativos|default:'—' }}</p></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Passageiros</p><p class="mt-3 text-3xl font-semibold text-white">{{ home_counts.passageiros|default:'—' }}</p></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">Viagens</p><p class="mt-3 text-3xl font-semibold text-white">{{ home_counts.viagens|default:'—' }}</p></article>
+  </section>
+  <section class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+    {% for card in resumo_cards %}
+      <article class="rounded border border-gray-700 bg-gray-800 p-6">
+        <p class="text-sm uppercase text-gray-400">{{ card.titulo }}</p>
+        <p class="mt-3 text-3xl font-semibold text-white">{{ card.valor }}</p>
+        <p class="mt-2 text-sm text-gray-400">{{ card.descricao }}</p>
+      </article>
+    {% endfor %}
   </section>
 
-  {% if view_type != "parceiros" %}
-  <section class="surface-card stacked">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Programas</p>
-        <h2 class="section-title">Pontos, valores e referências</h2>
-      </div>
-    </div>
-    <div class="stat-grid stats-grid">
-      {% for prog in programas %}
-        <div class="stat-card">
-          <p class="stat-label">{{ prog.nome }}</p>
-          <p class="stat-value">{{ prog.pontos }}</p>
-          <p class="stat-meta">Pontos acumulados</p>
-          <div class="section-divider"></div>
-          <p class="label">Valor total</p>
-          <p class="stat-meta">R$ {{ prog.valor_total|floatformat:2 }}</p>
-          <p class="label">Valor médio por 1.000</p>
-          <p class="stat-meta">R$ {{ prog.valor_medio|floatformat:2 }}</p>
-          <p class="label">Valor de referência atual</p>
-          <p class="stat-meta">R$ {{ prog.valor_referencia|floatformat:2 }}</p>
-          {% if prog.conta_id %}
-          <a class="card-link btn btn--ghost" href="{% url 'admin_movimentacoes' prog.conta_id %}">Ver movimentações</a>
-          {% endif %}
-        </div>
-      {% empty %}
-        <p class="muted">Nenhum programa encontrado.</p>
-      {% endfor %}
-    </div>
+  <section class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <article class="rounded border border-gray-700 bg-gray-800 p-8 text-center">
+      <p class="text-sm uppercase text-gray-400">Emissões no período</p>
+      <p class="mt-4 text-6xl font-semibold text-white">{{ management_dashboard.summary.total_emissoes }}</p>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-8 text-center">
+      <p class="text-sm uppercase text-gray-400">Receita total</p>
+      <p class="mt-4 text-6xl font-semibold text-white">{{ management_dashboard.summary.receita_total }}</p>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-8 text-center">
+      <p class="text-sm uppercase text-gray-400">Lucro líquido</p>
+      <p class="mt-4 text-6xl font-semibold text-white">{{ management_dashboard.summary.lucro_total }}</p>
+    </article>
   </section>
-  {% endif %}
 
-  {% if view_type == "parceiros" %}
-  <section class="surface-card stacked">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Emissores parceiros</p>
-        <h2 class="section-title">Cards por parceiro</h2>
-      </div>
-    </div>
-    {% if parceiros_cards %}
-      <div class="stat-grid stats-grid">
-        {% for card in parceiros_cards %}
-          <div class="stat-card">
-            <p class="stat-label">{{ card.nome }}</p>
-            <p class="stat-value">{{ card.total_emissoes }}</p>
-            <p class="stat-meta">Emissões registradas</p>
-            <ul class="list-plain">
-              <li>Total de milhas: <strong>{{ card.total_milhas }}</strong></li>
-              <li>Valor pago: <strong>R$ {{ card.valor_pago|floatformat:2 }}</strong></li>
-              <li>Valor médio do milheiro: <strong>R$ {{ card.valor_medio_milheiro|floatformat:2 }}</strong></li>
-            </ul>
+  <section class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Programas de Fidelidade</h2>
+      <div class="h-[200px] space-y-3 overflow-y-auto">
+        {% for programa in programas_info|slice:":4" %}
+          <div class="rounded border border-gray-700 bg-gray-900 p-4">
+            <div class="flex items-center justify-between gap-3">
+              <span class="text-sm text-white">{{ programa.nome }}</span>
+              <span class="text-sm text-gray-400">{{ programa.pontos }}</span>
+            </div>
+            <p class="mt-2 text-xs text-gray-400">Valor total {{ programa.valor_total|floatformat:2 }} • Ref. {{ programa.valor_referencia|floatformat:2 }}</p>
           </div>
+        {% empty %}
+          <div class="flex h-full items-center justify-center rounded border border-gray-700 bg-gray-900 text-sm text-gray-400">Sem programas cadastrados.</div>
         {% endfor %}
       </div>
-    {% else %}
-      <p class="muted">Nenhuma emissão encontrada para parceiros.</p>
-    {% endif %}
-  </section>
-  {% endif %}
-
-  <section class="surface-card stacked">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Resumo financeiro</p>
-        <h2 class="section-title">{% if view_type == "parceiros" %}Emissões e vendas{% else %}Emissões e Hotéis{% endif %}</h2>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Série Temporal</h2>
+      <div class="flex h-[200px] items-end justify-between gap-3 rounded border border-gray-700 bg-gray-900 p-4">
+        {% for point in management_dashboard.timeline_series|slice:":8" %}
+          <div class="flex flex-1 flex-col items-center gap-2">
+            <div class="w-full rounded-t bg-blue-400 {% cycle 'h-16' 'h-24' 'h-20' 'h-28' 'h-32' 'h-24' 'h-20' 'h-28' %}"></div>
+            <span class="text-[10px] text-gray-400">{{ point.label }}</span>
+          </div>
+        {% empty %}
+          <div class="flex h-full w-full items-center justify-center text-sm text-gray-400">Sem dados no período selecionado.</div>
+        {% endfor %}
       </div>
-    </div>
-    <div class="stat-grid stats-grid">
-      <div class="stat-card primary">
-        <p class="stat-label">Emissões</p>
-        <p class="stat-value">{{ emissoes.qtd }}</p>
-        <p class="stat-meta">Quantidade total de emissões</p>
-        <ul class="list-plain">
-          {% if view_type == "parceiros" %}
-            <li>Total de milhas emitidas: <strong>{{ parceiros.milhas }}</strong></li>
-            <li>Valor pago ao parceiro: <strong>R$ {{ parceiros.valor_pago|floatformat:2 }}</strong></li>
-            <li>Valor médio do milheiro: <strong>R$ {{ parceiros.valor_medio_milheiro|floatformat:2 }}</strong></li>
-            <li>Lucro: <strong>R$ {{ parceiros.lucro|floatformat:2 }}</strong></li>
-          {% else %}
-            <li>Total de pontos usados: <strong>{{ emissoes.pontos }}</strong></li>
-            <li>Valor ref.: <strong>R$ {{ emissoes.valor_referencia|floatformat:2 }}</strong></li>
-            <li>Taxas*: <strong>R$ {{ emissoes.valor_taxas|floatformat:2 }}</strong></li>
-            <li>Custo total: <strong>R$ {{ emissoes.custo_total|floatformat:2 }}</strong></li>
-            <li>Economizado: <strong>R$ {{ emissoes.valor_economizado|floatformat:2 }}</strong></li>
-          {% endif %}
-        </ul>
-        {% if view_type != "parceiros" %}
-        <p class="helper-text mt-3">*Taxas de embarque/companhia aérea.</p>
-        {% endif %}
-        <a class="card-link btn btn--ghost" href="{% url 'admin_emissoes' %}">Ver detalhes</a>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Receita x Lucro</h2>
+      <div class="h-[200px] space-y-3 overflow-y-auto rounded border border-gray-700 bg-gray-900 p-4">
+        {% for item in management_dashboard.cost_vs_sale|slice:":4" %}
+          <div class="rounded border border-gray-700 p-4">
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-white">{{ item.programa }}</span>
+              <span class="text-gray-400">{{ item.margem_media }}</span>
+            </div>
+            <div class="mt-3 flex h-3 gap-2">
+              <div class="w-1/2 rounded-full bg-[#fbbf24]"></div>
+              <div class="w-1/2 rounded-full bg-[#10b981]"></div>
+            </div>
+            <div class="mt-2 flex items-center justify-between text-xs text-gray-400">
+              <span>Custo {{ item.custo_medio }}</span>
+              <span>Venda {{ item.venda_media }}</span>
+            </div>
+          </div>
+        {% empty %}
+          <div class="flex h-full items-center justify-center text-sm text-gray-400">Sem comparativos disponíveis.</div>
+        {% endfor %}
       </div>
-      {% if view_type != "parceiros" %}
-      <div class="stat-card">
-        <p class="stat-label">Hotéis</p>
-        <p class="stat-value">{{ hoteis.qtd }}</p>
-        <p class="stat-meta">Reservas confirmadas</p>
-        <ul class="list-plain">
-          <li>Valor ref. acumulado: <strong>R$ {{ hoteis.valor_referencia|floatformat:2 }}</strong></li>
-          <li>Valor pago: <strong>R$ {{ hoteis.valor_pago|floatformat:2 }}</strong></li>
-          <li>Economizado: <strong>R$ {{ hoteis.valor_economizado|floatformat:2 }}</strong></li>
-        </ul>
-        <a class="card-link btn btn--ghost" href="{% url 'admin_hoteis' %}">Ver detalhes</a>
-      </div>
-      {% endif %}
-    </div>
+    </article>
   </section>
 
-  <section class="surface-card">
-    <div class="section-heading">
-      <div>
-        <p class="eyebrow">Distribuição</p>
-        <h2 class="section-title">Emissões por programa</h2>
+  <section class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6 lg:col-span-2">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Principais Indicadores da Operação</h2>
+      <div class="h-[250px] rounded border border-gray-700 bg-gray-900 p-6">
+        <div class="grid h-full grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="space-y-3 overflow-y-auto">
+            {% for item in management_dashboard.best_programs|slice:":4" %}
+              <div class="rounded border border-gray-700 bg-gray-800/50 p-4">
+                <div class="flex items-center justify-between gap-3"><span class="text-sm text-white">{{ item.nome }}</span><span class="text-sm text-green-500">{{ item.lucro }}</span></div>
+                <p class="mt-2 text-xs text-gray-400">{{ item.qtd }} emissões • receita {{ item.receita }}</p>
+              </div>
+            {% empty %}
+              <div class="flex h-full items-center justify-center rounded border border-gray-700 bg-gray-800/50 text-sm text-gray-400">Sem programas em destaque.</div>
+            {% endfor %}
+          </div>
+          <div class="space-y-3 overflow-y-auto">
+            {% for item in management_dashboard.worst_programs|slice:":4" %}
+              <div class="rounded border border-gray-700 bg-gray-800/50 p-4">
+                <div class="flex items-center justify-between gap-3"><span class="text-sm text-white">{{ item.nome }}</span><span class="text-sm text-red-500">{{ item.lucro }}</span></div>
+                <p class="mt-2 text-xs text-gray-400">{{ item.qtd }} emissões • receita {{ item.receita }}</p>
+              </div>
+            {% empty %}
+              <div class="flex h-full items-center justify-center rounded border border-gray-700 bg-gray-800/50 text-sm text-gray-400">Sem alertas de pior resultado.</div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Alertas / Aeroportos</h2>
+      <div class="max-h-[280px] space-y-2 overflow-y-auto">
+        {% for alerta in alertas_info|slice:":6" %}
+          <div class="rounded border border-gray-700 bg-gray-900 p-4">
+            <div class="mb-2 flex items-center justify-between gap-3 text-sm"><span class="text-white">{{ alerta.origem }} → {{ alerta.destino }}</span><span class="text-gray-400">{{ alerta.status }}</span></div>
+            <div class="h-6 rounded-full bg-gray-700"><div class="h-6 rounded-full bg-blue-400 {% cycle 'w-3/4' 'w-2/3' 'w-1/2' 'w-1/3' %}"></div></div>
+            <p class="mt-2 text-xs text-gray-400">{{ alerta.datas_resumo }}</p>
+          </div>
+        {% empty %}
+          <div class="rounded border border-gray-700 bg-gray-900 p-4 text-sm text-gray-400">Sem alertas ativos.</div>
+        {% endfor %}
+      </div>
+    </article>
+  </section>
+
+  <section class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Top Emissores</h2>
+      <div class="h-[200px] space-y-3 overflow-y-auto rounded border border-gray-700 bg-gray-900 p-4">
+        {% for item in management_dashboard.top_emitters|slice:":6" %}
+          <div class="flex items-center justify-between rounded border border-gray-700 px-4 py-3">
+            <span class="text-sm text-white">{{ item.nome }}</span>
+            <span class="text-sm text-purple-500">{{ item.lucro }}</span>
+          </div>
+        {% empty %}
+          <div class="flex h-full items-center justify-center text-sm text-gray-400">Sem emissores disponíveis.</div>
+        {% endfor %}
+      </div>
+    </article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6">
+      <h2 class="mb-4 text-center text-lg font-semibold text-white">Companhias Aéreas</h2>
+      <div class="h-[200px] space-y-3 overflow-y-auto rounded border border-gray-700 bg-gray-900 p-4">
+        {% for item in management_dashboard.top_airlines|slice:":6" %}
+          <div class="flex items-center justify-between rounded border border-gray-700 px-4 py-3">
+            <span class="text-sm text-white">{{ item.nome }}</span>
+            <span class="text-sm text-yellow-500">{{ item.lucro }}</span>
+          </div>
+        {% empty %}
+          <div class="flex h-full items-center justify-center text-sm text-gray-400">Sem companhias disponíveis.</div>
+        {% endfor %}
+      </div>
+    </article>
+  </section>
+
+  <section class="overflow-hidden rounded border border-gray-700 bg-gray-800">
+    <div class="border-b border-gray-700 px-6 py-4">
+      <h2 class="text-lg font-semibold text-white">Tabela de Voos</h2>
     </div>
-    <canvas id="emissoesChart"></canvas>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-700">
+        <thead class="bg-gray-900 text-xs uppercase text-gray-300">
+          <tr>
+            <th class="px-4 py-3 text-left">Data</th>
+            <th class="px-4 py-3 text-left">Cliente</th>
+            <th class="px-4 py-3 text-left">Emissor</th>
+            <th class="px-4 py-3 text-left">Programa</th>
+            <th class="px-4 py-3 text-left">Companhia</th>
+            <th class="px-4 py-3 text-left">Receita</th>
+            <th class="px-4 py-3 text-left">Lucro</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-700">
+          {% for row in management_dashboard.emissions_rows %}
+            <tr class="hover:bg-gray-750">
+              <td class="px-4 py-3 text-gray-200">{{ row.data }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.cliente }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.emissor }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.programa }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.companhia }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.receita }}</td>
+              <td class="px-4 py-3 text-gray-200">{{ row.lucro }}</td>
+            </tr>
+          {% empty %}
+            <tr class="hover:bg-gray-750"><td colspan="7" class="px-4 py-3 text-gray-200">Nenhuma emissão encontrada.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </section>
 </div>
-{% endblock %}
-
-{% block extra_body %}
-<script>
-const viewSelect = document.getElementById('viewSelect');
-const clienteSelect = document.getElementById('clienteSelect');
-const contaSelect = document.getElementById('contaSelect');
-const emissorSelect = document.getElementById('emissorSelect');
-
-function buildDashboardUrl() {
-  const base = '{% url "admin_dashboard" %}';
-  const view = viewSelect ? viewSelect.value : 'clientes';
-  const params = new URLSearchParams({ view });
-  if (view === 'clientes' && clienteSelect && clienteSelect.value) {
-    params.set('cliente_id', clienteSelect.value);
-  }
-  if (view === 'contas' && contaSelect && contaSelect.value) {
-    params.set('conta_id', contaSelect.value);
-  }
-  if (view === 'parceiros' && emissorSelect && emissorSelect.value) {
-    params.set('emissor_id', emissorSelect.value);
-  }
-  return `${base}?${params.toString()}`;
-}
-
-function toggleFilters() {
-  const view = viewSelect ? viewSelect.value : 'clientes';
-  document.querySelectorAll('[data-filter-type]').forEach((el) => {
-    el.style.display = el.dataset.filterType === view ? 'block' : 'none';
-  });
-}
-
-if (viewSelect) {
-  viewSelect.addEventListener('change', () => {
-    toggleFilters();
-    window.location = buildDashboardUrl();
-  });
-}
-if (clienteSelect) {
-  clienteSelect.addEventListener('change', () => {
-    window.location = buildDashboardUrl();
-  });
-}
-if (contaSelect) {
-  contaSelect.addEventListener('change', () => {
-    window.location = buildDashboardUrl();
-  });
-}
-if (emissorSelect) {
-  emissorSelect.addEventListener('change', () => {
-    window.location = buildDashboardUrl();
-  });
-}
-toggleFilters();
-
-const ctx = document.getElementById('emissoesChart');
-if (ctx) {
-  const labels = [{% for item in emissoes_programa %}'{{ item.programa }}'{% if not forloop.last %},{% endif %}{% endfor %}];
-  const dataVals = [{% for item in emissoes_programa %}{{ item.quantidade }}{% if not forloop.last %},{% endif %}{% endfor %}];
-  const primaryToken = getComputedStyle(document.documentElement).getPropertyValue('--primary').trim();
-  const primaryColor = primaryToken ? `hsl(${primaryToken})` : 'hsl(217 91% 60%)';
-
-  new Chart(ctx, {
-    type: 'bar',
-    data: { 
-      labels, 
-      datasets: [{ 
-        label: 'Emissões', 
-        data: dataVals, 
-        backgroundColor: primaryColor 
-      }] 
-    },
-    options: { scales: { y: { beginAtZero: true } } }
-  });
-}
-</script>
 {% endblock %}

--- a/gestao/templates/admin_custom/home.html
+++ b/gestao/templates/admin_custom/home.html
@@ -1,0 +1,27 @@
+{% extends "admin_custom/base_admin.html" %}
+{% block title %}Home da Gestão{% endblock %}
+{% block header_title %}Home da Gestão{% endblock %}
+{% block header_subtitle %}<span>Visão operacional do dia com alertas, movimentos e atalhos da gestão.</span>{% endblock %}
+{% block header_actions %}
+<a href="{% url 'admin_dashboard_analytics' %}" class="rounded border border-gray-700 bg-gray-900 px-4 py-2 text-sm text-white">Abrir Dashboard</a>
+{% endblock %}
+{% block content %}
+<div class="space-y-6 py-2">
+  <section class="rounded border border-gray-700 bg-gray-800 p-6">
+    <h2 class="text-2xl font-semibold text-white">Bem-vindo à operação</h2>
+    <p class="mt-2 text-sm text-gray-400">Período atual: {{ home_period_label }}</p>
+  </section>
+  <section class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+    {% for item in home_kpis %}<article class="rounded border border-gray-700 bg-gray-800 p-6"><p class="text-sm uppercase text-gray-400">{{ item.label }}</p><p class="mt-3 text-3xl font-semibold text-white">{{ item.value }}</p></article>{% endfor %}
+  </section>
+  <section class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><h2 class="mb-4 text-lg font-semibold text-white">Alertas importantes</h2><div class="space-y-3">{% for alert in home_alerts %}<div class="rounded border border-gray-700 bg-gray-900 p-4"><div class="flex items-center justify-between"><span class="text-white">{{ alert.titulo }}</span><span class="text-xs text-gray-400">{{ alert.tone }}</span></div><p class="mt-2 text-sm text-gray-400">{{ alert.descricao }}</p></div>{% empty %}<div class="rounded border border-gray-700 bg-gray-900 p-4 text-sm text-gray-400">Sem alertas relevantes.</div>{% endfor %}</div></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><h2 class="mb-4 text-lg font-semibold text-white">Ações rápidas</h2><div class="grid grid-cols-1 gap-3">{% for action in home_actions %}<a href="{% url action.url %}" class="rounded border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-white hover:bg-gray-750">{{ action.label }}</a>{% endfor %}</div></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><h2 class="mb-4 text-lg font-semibold text-white">Resumo financeiro</h2><div class="space-y-3"><div class="rounded border border-gray-700 bg-gray-900 p-4"><p class="text-sm text-gray-400">Receita no período</p><p class="mt-2 text-2xl font-semibold text-white">{{ home_financial.receita }}</p></div><div class="rounded border border-gray-700 bg-gray-900 p-4"><p class="text-sm text-gray-400">Custo no período</p><p class="mt-2 text-2xl font-semibold text-white">{{ home_financial.custo }}</p></div><div class="rounded border border-gray-700 bg-gray-900 p-4"><p class="text-sm text-gray-400">Lucro / Ticket médio</p><p class="mt-2 text-xl font-semibold text-white">{{ home_financial.lucro }} • {{ home_financial.ticket_medio }}</p></div></div></article>
+  </section>
+  <section class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><h2 class="mb-4 text-lg font-semibold text-white">Últimas movimentações</h2><div class="space-y-3">{% for item in home_latest_movements %}<div class="rounded border border-gray-700 bg-gray-900 p-4"><div class="flex items-center justify-between gap-3"><span class="text-white">{{ item.tipo }}</span><span class="text-xs text-gray-400">{{ item.meta }}</span></div><p class="mt-2 text-sm text-gray-400">{{ item.titulo }}</p></div>{% empty %}<div class="rounded border border-gray-700 bg-gray-900 p-4 text-sm text-gray-400">Sem movimentações recentes.</div>{% endfor %}</div></article>
+    <article class="rounded border border-gray-700 bg-gray-800 p-6"><h2 class="mb-4 text-lg font-semibold text-white">Próximos embarques</h2><div class="space-y-3">{% for item in home_upcoming_boardings %}<div class="rounded border border-gray-700 bg-gray-900 p-4"><div class="flex items-center justify-between gap-3"><span class="text-white">{{ item.cliente }}</span><span class="text-xs text-gray-400">{{ item.status }}</span></div><p class="mt-2 text-sm text-gray-400">{{ item.rota }} • {{ item.data }} • {{ item.companhia }} • {{ item.localizador }}</p></div>{% empty %}<div class="rounded border border-gray-700 bg-gray-900 p-4 text-sm text-gray-400">Sem embarques próximos.</div>{% endfor %}</div></article>
+  </section>
+</div>
+{% endblock %}

--- a/gestao/urls_admin.py
+++ b/gestao/urls_admin.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from gestao.views import (
+    admin_home,
     admin_dashboard,
     admin_clientes,
     admin_contas,
@@ -65,7 +66,8 @@ from gestao.views import (
 )
 
 urlpatterns = [
-    path('painel/', admin_dashboard, name='admin_dashboard'),
+    path('painel/', admin_home, name='admin_dashboard'),
+    path('painel/dashboard/', admin_dashboard, name='admin_dashboard_analytics'),
     path('clientes/', admin_clientes, name='admin_clientes'),
     path('clientes/<int:cliente_id>/editar/', editar_cliente, name='admin_editar_cliente'),
     path('clientes/novo/', criar_cliente, name='admin_novo_cliente'),

--- a/gestao/views/clientes.py
+++ b/gestao/views/clientes.py
@@ -135,12 +135,17 @@ def admin_clientes(request):
         return redirect("admin_clientes")
 
     busca = request.GET.get("busca", "")
+    status = request.GET.get("status", "")
     clientes = Cliente.objects.filter(perfil="cliente").select_related("usuario")
     if busca:
         clientes = clientes.filter(
             Q(usuario__username__icontains=busca)
             | Q(usuario__first_name__icontains=busca)
         )
+    if status == "ativo":
+        clientes = clientes.filter(ativo=True)
+    elif status == "inativo":
+        clientes = clientes.filter(ativo=False)
 
     paginator = Paginator(clientes, 20)
     page_number = request.GET.get("page")
@@ -151,6 +156,7 @@ def admin_clientes(request):
         {
             "page_obj": page_obj,
             "busca": busca,
+            "status": status,
             "total_clientes": clientes.count(),
             "menu_ativo": "clientes",
         },

--- a/gestao/views/dashboard.py
+++ b/gestao/views/dashboard.py
@@ -1,9 +1,10 @@
 from decimal import Decimal
 
 from django.contrib.auth.decorators import login_required
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.http import JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 
 from ..models import (
     Cliente,
@@ -13,6 +14,9 @@ from ..models import (
     EmissaoPassagem,
     EmissorParceiro,
     Empresa,
+    CotacaoVoo,
+    Movimentacao,
+    Passageiro,
 )
 from ..services.dashboard import build_operational_dashboard_context
 from ..value_utils import build_valor_milheiro_map, get_valor_referencia_from_map
@@ -224,6 +228,155 @@ def build_dashboard_metrics(view_type="clientes", entity_id=None):
     }
 
 
+def _build_home_context(*, user, empresa=None, request=None):
+    today = timezone.localdate()
+    start_date = today.replace(day=1)
+    emissoes_qs = EmissaoPassagem.objects.select_related("cliente__usuario", "companhia_aerea", "aeroporto_partida", "aeroporto_destino")
+    cotacoes_qs = CotacaoVoo.objects.select_related("cliente__usuario", "origem", "destino", "programa")
+    contas_qs = ContaAdministrada.objects.all()
+    clientes_qs = Cliente.objects.filter(perfil="cliente")
+    movimentacoes_qs = Movimentacao.objects.select_related("conta", "conta__programa", "conta__cliente__usuario")
+    if empresa:
+        emissoes_qs = emissoes_qs.filter(Q(cliente__empresa=empresa) | Q(conta_administrada__empresa=empresa))
+        cotacoes_qs = cotacoes_qs.filter(Q(cliente__empresa=empresa) | Q(conta_administrada__empresa=empresa))
+        contas_qs = contas_qs.filter(empresa=empresa)
+        clientes_qs = clientes_qs.filter(empresa=empresa)
+        movimentacoes_qs = movimentacoes_qs.filter(Q(conta__cliente__empresa=empresa) | Q(conta__conta_administrada__empresa=empresa))
+
+    emissoes_hoje = emissoes_qs.filter(criado_em__date=today)
+    emissoes_periodo = emissoes_qs.filter(criado_em__date__gte=start_date, criado_em__date__lte=today)
+    lucro_hoje = sum(float(e.lucro or 0) for e in emissoes_hoje)
+    lucro_periodo = sum(float(e.lucro or 0) for e in emissoes_periodo)
+    milhas_periodo = sum(int(e.pontos_utilizados or 0) for e in emissoes_periodo)
+    receita_periodo = sum(float((e.valor_total_final if e.valor_total_final not in (None, '') else (e.valor_venda_final or 0)) or 0) for e in emissoes_periodo)
+    custo_periodo = sum(float(e.custo_total or 0) for e in emissoes_periodo)
+    ticket_medio = (receita_periodo / emissoes_periodo.count()) if emissoes_periodo.count() else 0
+
+    alerts = []
+    low_balance = []
+    for conta in ContaFidelidade.objects.select_related("programa", "cliente__usuario", "conta_administrada")[:30]:
+        saldo = getattr(conta.conta_saldo(), 'saldo_pontos', 0)
+        if saldo and saldo < 10000:
+            titular = conta.cliente or conta.conta_administrada
+            low_balance.append({
+                'titulo': 'Conta com saldo baixo',
+                'descricao': f'{titular} em {conta.programa.nome} com {saldo} pontos',
+                'url': None,
+                'tone': 'yellow',
+            })
+            if len(low_balance) >= 2:
+                break
+    alerts.extend(low_balance)
+    loss_emission = emissoes_periodo.filter(lucro__lt=0).first()
+    if loss_emission:
+        alerts.append({'titulo': 'Emissão com prejuízo', 'descricao': str(loss_emission), 'url': None, 'tone': 'red'})
+    upcoming = emissoes_qs.filter(data_ida__date__gte=today).order_by('data_ida')[:3]
+    if upcoming:
+        alerts.append({'titulo': 'Embarques próximos', 'descricao': f'{upcoming.count()} embarques previstos para os próximos dias', 'url': None, 'tone': 'blue'})
+    pending_quote = cotacoes_qs.filter(status='pendente').first()
+    if pending_quote:
+        alerts.append({'titulo': 'Cotações sem retorno', 'descricao': str(pending_quote), 'url': None, 'tone': 'purple'})
+
+    quick_actions = [
+        {'label': 'Nova emissão', 'url': 'admin_nova_emissao'},
+        {'label': 'Nova cotação', 'url': 'admin_nova_cotacao_voo'},
+        {'label': 'Novo cliente', 'url': 'admin_novo_cliente'},
+        {'label': 'Nova conta fidelidade', 'url': 'admin_nova_conta'},
+        {'label': 'Nova conta administrativa', 'url': 'admin_nova_conta_administrada'},
+        {'label': 'Emissões do dia', 'url': 'admin_emissoes'},
+        {'label': 'Auditorias', 'url': 'admin_auditoria'},
+    ]
+
+    latest_movements = []
+    for emissao in emissoes_qs.order_by('-criado_em')[:4]:
+        latest_movements.append({'tipo': 'Emissão', 'titulo': str(emissao), 'meta': timezone.localtime(emissao.criado_em).strftime('%d/%m/%Y %H:%M')})
+    for cotacao in cotacoes_qs.order_by('-criado_em')[:3]:
+        latest_movements.append({'tipo': 'Cotação', 'titulo': str(cotacao), 'meta': timezone.localtime(cotacao.criado_em).strftime('%d/%m/%Y %H:%M')})
+    for mov in movimentacoes_qs.order_by('-data')[:3]:
+        latest_movements.append({'tipo': 'Pontos', 'titulo': mov.descricao, 'meta': mov.data.strftime('%d/%m/%Y')})
+    latest_movements = sorted(latest_movements, key=lambda item: item['meta'], reverse=True)[:8]
+
+    upcoming_boardings = [
+        {
+            'cliente': (e.cliente or e.conta_administrada),
+            'rota': f"{getattr(e.aeroporto_partida, 'sigla', '—')} → {getattr(e.aeroporto_destino, 'sigla', '—')}",
+            'data': e.data_ida.strftime('%d/%m/%Y %H:%M') if e.data_ida else '—',
+            'companhia': getattr(e.companhia_aerea, 'nome', '—'),
+            'localizador': e.localizador or '—',
+            'status': 'Emitido' if e.localizador else 'Pendente',
+        }
+        for e in upcoming
+    ]
+
+    return {
+        'home_period_label': f'{start_date.strftime("%d/%m/%Y")} a {today.strftime("%d/%m/%Y")}',
+        'home_kpis': [
+            {'label': 'Emissões hoje', 'value': emissoes_hoje.count()},
+            {'label': 'Emissões no período', 'value': emissoes_periodo.count()},
+            {'label': 'Lucro hoje', 'value': f'R$ {lucro_hoje:,.2f}'},
+            {'label': 'Lucro no período', 'value': f'R$ {lucro_periodo:,.2f}'},
+            {'label': 'Milhas no período', 'value': milhas_periodo},
+            {'label': 'Clientes ativos', 'value': clientes_qs.filter(ativo=True).count()},
+            {'label': 'Contas administrativas ativas', 'value': contas_qs.filter(ativo=True).count()},
+            {'label': 'Cotações pendentes', 'value': cotacoes_qs.filter(status='pendente').count()},
+        ],
+        'home_alerts': alerts,
+        'home_actions': quick_actions,
+        'home_latest_movements': latest_movements,
+        'home_upcoming_boardings': upcoming_boardings,
+        'home_financial': {
+            'receita': f'R$ {receita_periodo:,.2f}',
+            'custo': f'R$ {custo_periodo:,.2f}',
+            'lucro': f'R$ {lucro_periodo:,.2f}',
+            'ticket_medio': f'R$ {ticket_medio:,.2f}',
+        },
+        'home_counts': {
+            'contas_fidelidade': ContaFidelidade.objects.count(),
+            'passageiros': Passageiro.objects.count(),
+            'viagens': emissoes_periodo.count(),
+            'clientes_ativos': clientes_qs.filter(ativo=True).count(),
+            'contas_administrativas_ativas': contas_qs.filter(ativo=True).count(),
+        },
+    }
+
+
+@login_required
+def admin_home(request):
+    if (permission_denied := require_admin_or_operator(request)):
+        return permission_denied
+    empresa = None
+    empresa_id = request.GET.get("empresa_id")
+    empresas = None
+    if request.user.is_superuser:
+        empresas = Empresa.objects.all().order_by("nome")
+        if empresa_id:
+            empresa = empresas.filter(id=empresa_id).first()
+    else:
+        empresa = getattr(getattr(request.user, "cliente_gestao", None), "empresa", None)
+
+    context = build_operational_dashboard_context(
+        user=request.user,
+        request=request,
+        empresa=empresa,
+        selected_continente=request.GET.get("continente"),
+        selected_pais=request.GET.get("pais"),
+        selected_cidade=request.GET.get("cidade"),
+    )
+    context.update(
+        {
+            "dashboard_base": "admin_custom/base_admin.html",
+            "dashboard_title": "Dashboard Operacional",
+            "dashboard_subtitle": "Visão operacional com alertas, emissões e ações prioritárias.",
+            "menu_ativo": "home",
+            "empresas": empresas,
+            "empresa_selecionada": empresa,
+            "empresa_id": empresa_id,
+        }
+    )
+    context.update(_build_home_context(user=request.user, empresa=empresa, request=request))
+    return render(request, "admin_custom/home.html", context)
+
+
 @login_required
 def admin_dashboard(request):
     if (permission_denied := require_admin_or_operator(request)):
@@ -257,7 +410,8 @@ def admin_dashboard(request):
             "empresa_id": empresa_id,
         }
     )
-    return render(request, "painel_cliente/dashboard.html", context)
+    context.update(_build_home_context(user=request.user, empresa=empresa, request=request))
+    return render(request, "admin_custom/dashboard.html", context)
 
 
 @login_required


### PR DESCRIPTION
### Motivation
- Modernize and unify the admin UI with a Tailwind-based layout and provide a concise operational "Home" view for daily operations. 
- Surface high-level summary metrics in the management dashboard to simplify KPI consumption. 
- Provide a streamlined navigation experience and expose an analytics dashboard path separate from the home landing. 
- Add basic filtering by `status` on the clients list to improve client management workflows.

### Description
- Reworked the admin shell and visual components in `gestao/templates/admin_custom/base_admin.html` to a Tailwind layout and updated header, navigation and responsive behaviour. 
- Replaced and refactored `dashboard.html` and `clientes.html` (and added `home.html`) to new componentized templates that consume the updated context keys and show compact cards, tables and lists. 
- Added a `summary` block to the management context in `gestao/services/dashboard.py` to expose formatted totals (`total_emissoes`, `receita_total`, `lucro_total`, `milhas_utilizadas`, `total_taxas`). 
- Implemented `_build_home_context` and `admin_home` in `gestao/views/dashboard.py` to construct the Home landing data (KPIs, alerts, quick actions, latest movements, upcoming boardings and financial summary) and wired it into the main `admin_dashboard` flow so analytics are available under `admin_dashboard_analytics`. 
- Updated `gestao/views/clientes.py` to accept a `status` GET parameter and filter clients by active/inactive, and pass `status` into the template; pagination and counts preserved. 
- Adjusted routes in `gestao/urls_admin.py` to point `painel/` to the new `admin_home` and `painel/dashboard/` to the analytics view `admin_dashboard`. 

### Testing
- Ran the Django test suite with `./manage.py test` and the tests completed successfully. 
- No new automated tests were introduced in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00018642483278907e01e2caddaaf)