### PR TITLE
Add multi-step emission wizard with autosave, validation and React components

### DIFF
--- a/gestao/static/gestao/formulario_base_gestao.css
+++ b/gestao/static/gestao/formulario_base_gestao.css
@@ -33,6 +33,65 @@
   margin: 0 0 0.5rem;
 }
 
+.wizard-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wizard-autosave {
+  font-size: 11px;
+  color: #34d399;
+  font-weight: 600;
+}
+
+.wizard-stepper {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.wizard-stepper__item {
+  border: 1px solid var(--border);
+  background: var(--color-input-bg);
+  color: var(--muted);
+  border-radius: 8px;
+  height: 34px;
+  font-size: 11px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.wizard-stepper__item span {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wizard-stepper__item.is-active {
+  color: #fff;
+  border-color: #3b82f6;
+  background: #2563eb;
+}
+
+.wizard-stepper__item.is-complete {
+  color: #fff;
+  border-color: #10b981;
+  background: #059669;
+}
+
+.wizard-stepper__item:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .form-shell {
   display: flex;
   flex-direction: column;
@@ -373,6 +432,38 @@ textarea:focus {
   color: var(--heading);
 }
 
+.review-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.review-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--color-input-bg);
+}
+
+.review-card p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.review-card button {
+  width: fit-content;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--heading);
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
 @media (max-width: 640px) {
   .form-wrapper {
     padding: 0.75rem;
@@ -386,6 +477,15 @@ textarea:focus {
     position: static;
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .wizard-stepper {
+    display: flex;
+    overflow-x: auto;
+  }
+
+  .wizard-stepper__item {
+    min-width: 120px;
   }
 }
 

--- a/gestao/templates/admin_custom/form_emissao_passagem.html
+++ b/gestao/templates/admin_custom/form_emissao_passagem.html
@@ -32,7 +32,19 @@
         <p class="form-subtitle">Fluxo organizado: cliente, trechos, horários, passageiros, escalas e valores.</p>
     </div>
 
-    <div class="section-card">
+    <div class="wizard-header">
+        <div id="wizard-autosave" class="wizard-autosave">Rascunho local ativo</div>
+        <div class="wizard-stepper" id="wizard-stepper">
+            <button type="button" class="wizard-stepper__item is-active" data-go-step="1"><span>1</span> Cliente</button>
+            <button type="button" class="wizard-stepper__item" data-go-step="2"><span>2</span> Ida</button>
+            <button type="button" class="wizard-stepper__item" data-go-step="3"><span>3</span> Volta</button>
+            <button type="button" class="wizard-stepper__item" data-go-step="4"><span>4</span> Passageiros</button>
+            <button type="button" class="wizard-stepper__item" data-go-step="5"><span>5</span> Valores</button>
+            <button type="button" class="wizard-stepper__item" data-go-step="6"><span>6</span> Revisão</button>
+        </div>
+    </div>
+
+    <div class="section-card wizard-step" data-step="1">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Dados do cliente</p>
@@ -74,7 +86,7 @@
         </div>
     </div>
 
-    <div class="section-card">
+    <div class="section-card wizard-step" data-step="2">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Detalhes do voo</p>
@@ -110,16 +122,9 @@
             <p class="helper-text">Ative para adicionar escalas no voo de ida.</p>
         </div>
         <hr class="section-divider" />
-        <div class="toggle-row">
-            <label class="toggle-pill" for="possui-volta">
-                <input type="checkbox" id="possui-volta" class="w-4 h-4" />
-                Possui volta?
-            </label>
-            <p class="helper-text">Ative para informar o trecho de retorno.</p>
-        </div>
     </div>
 
-    <div id="escala-ida-wrapper" class="section-card collapse-section">
+    <div id="escala-ida-wrapper" class="section-card collapse-section wizard-step" data-step="2">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Escalas</p>
@@ -133,7 +138,17 @@
         <button type="button" class="btn btn--outline btn--sm" data-add-escala="ida">+ Adicionar escala</button>
     </div>
 
-    <div id="voo-volta-card" class="section-card collapse-section">
+    <div class="section-card wizard-step" data-step="3">
+        <div class="toggle-row">
+            <label class="toggle-pill" for="possui-volta">
+                <input type="checkbox" id="possui-volta" class="w-4 h-4" />
+                Possui voo de volta?
+            </label>
+            <p class="helper-text">Ative para informar o trecho de retorno.</p>
+        </div>
+    </div>
+
+    <div id="voo-volta-card" class="section-card collapse-section wizard-step" data-step="3">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Retorno</p>
@@ -157,7 +172,7 @@
         </div>
     </div>
 
-    <div id="escala-volta-wrapper" class="section-card collapse-section">
+    <div id="escala-volta-wrapper" class="section-card collapse-section wizard-step" data-step="3">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Escalas</p>
@@ -171,7 +186,7 @@
         <button type="button" class="btn btn--outline btn--sm" data-add-escala="volta">+ Adicionar escala</button>
     </div>
 
-    <div class="section-card">
+    <div class="section-card wizard-step" data-step="4">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Passageiros</p>
@@ -202,7 +217,7 @@
         </div>
     </div>
 
-    <div class="section-card">
+    <div class="section-card wizard-step" data-step="5">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Valores e financeiro</p>
@@ -292,7 +307,18 @@
         </div>
     </div>
 
-    <div class="section-card">
+    <div class="section-card wizard-step" data-step="6" id="review-step-card">
+        <div class="section-card__header">
+            <div>
+                <p class="eyebrow">Revisão final</p>
+                <h2 class="section-card__title">Confira os dados antes de salvar</h2>
+                <p class="section-card__description">Use “Editar” para voltar em qualquer etapa sem perder informações.</p>
+            </div>
+        </div>
+        <div id="review-grid" class="review-grid"></div>
+    </div>
+
+    <div class="section-card wizard-step" data-step="6">
         <div class="section-card__header">
             <div>
                 <p class="eyebrow">Ações finais</p>
@@ -302,6 +328,8 @@
         </div>
         <div class="form-actions">
             <a href="{% url 'admin_emissoes' %}" class="btn btn--outline">Cancelar</a>
+            <button type="button" class="btn btn--outline" id="wizard-prev">← Voltar</button>
+            <button type="button" class="btn btn--outline" id="wizard-next">Próximo →</button>
             <button class="btn" type="submit" id="submit-emissao">💾 Salvar emissão</button>
         </div>
     </div>
@@ -950,5 +978,127 @@ function updateResumoVisual(){
         resumoValores.textContent = `${valorTxt} • ${taxasTxt} • ${pontosTxt}`;
     }
 }
+
+const DRAFT_KEY = "emission_draft_v2";
+let currentStep = 1;
+const totalSteps = 6;
+const wizardSteps = Array.from(document.querySelectorAll('.wizard-step'));
+const stepperItems = Array.from(document.querySelectorAll('.wizard-stepper__item'));
+const prevButton = document.getElementById('wizard-prev');
+const nextButton = document.getElementById('wizard-next');
+const autosaveLabel = document.getElementById('wizard-autosave');
+const reviewGrid = document.getElementById('review-grid');
+
+function isVisible(el) {
+    return !!(el && (el.offsetWidth || el.offsetHeight || el.getClientRects().length));
+}
+
+function validateStep(step) {
+    const scope = wizardSteps.filter((el) => Number(el.dataset.step) === step && isVisible(el));
+    for (const block of scope) {
+        const requiredFields = block.querySelectorAll('input[required], select[required], textarea[required]');
+        for (const field of requiredFields) {
+            if (!field.value) {
+                field.focus();
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+function setStep(step) {
+    currentStep = Math.max(1, Math.min(totalSteps, step));
+    wizardSteps.forEach((item) => {
+        item.style.display = Number(item.dataset.step) === currentStep ? '' : 'none';
+    });
+    stepperItems.forEach((item) => {
+        const itemStep = Number(item.dataset.goStep);
+        item.classList.toggle('is-active', itemStep === currentStep);
+        item.classList.toggle('is-complete', itemStep < currentStep);
+        item.disabled = itemStep > currentStep;
+    });
+    if (prevButton) prevButton.style.display = currentStep === 1 ? 'none' : 'inline-flex';
+    if (nextButton) nextButton.style.display = currentStep === totalSteps ? 'none' : 'inline-flex';
+    if (submitButton) submitButton.style.display = currentStep === totalSteps ? 'inline-flex' : 'none';
+    updateReview();
+}
+
+function saveDraft() {
+    const payload = {};
+    document.querySelectorAll('input, select, textarea').forEach((field) => {
+        if (!field.name || field.name === 'csrfmiddlewaretoken') return;
+        payload[field.name] = field.type === 'checkbox' ? field.checked : field.value;
+    });
+    payload.__step = currentStep;
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(payload));
+    if (autosaveLabel) {
+        autosaveLabel.textContent = `Autossalvo agora • ${new Date().toLocaleTimeString('pt-BR')}`;
+    }
+}
+
+function restoreDraft() {
+    try {
+        const raw = localStorage.getItem(DRAFT_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        Object.entries(data).forEach(([name, value]) => {
+            if (name === '__step') return;
+            const field = document.querySelector(`[name="${name}"]`);
+            if (!field) return;
+            if (field.type === 'checkbox') {
+                field.checked = Boolean(value);
+            } else {
+                field.value = value;
+            }
+        });
+        if (Number(data.__step)) currentStep = Number(data.__step);
+    } catch (e) {
+        console.warn('Não foi possível recuperar rascunho', e);
+    }
+}
+
+function updateReview() {
+    if (!reviewGrid) return;
+    const clienteTxt = clienteSelect?.selectedOptions?.[0]?.text || 'Não informado';
+    const programaTxt = programaSelect?.selectedOptions?.[0]?.text || 'Não informado';
+    const idaTxt = `${document.getElementById('id_aeroporto_partida')?.selectedOptions?.[0]?.text || '-'} → ${document.getElementById('id_aeroporto_destino')?.selectedOptions?.[0]?.text || '-'}`;
+    const voltaTxt = document.getElementById('id_data_volta')?.value || 'Sem volta';
+    const valorTotalTxt = valorTotalFinalField?.value || vendaFinalField?.value || '0,00';
+    const lucroTxt = lucroField?.value || '0,00';
+    const passageirosQtd = (parseInt(document.getElementById('id_qtd_adultos')?.value || 0, 10) + parseInt(document.getElementById('id_qtd_criancas')?.value || 0, 10) + parseInt(document.getElementById('id_qtd_bebes')?.value || 0, 10));
+    reviewGrid.innerHTML = `
+        <div class="review-card"><strong>Cliente & Programa</strong><p>${clienteTxt}</p><p>${programaTxt}</p><button type="button" data-edit-step="1">Editar</button></div>
+        <div class="review-card"><strong>Voos</strong><p>Ida: ${idaTxt}</p><p>Volta: ${voltaTxt}</p><button type="button" data-edit-step="2">Editar</button></div>
+        <div class="review-card"><strong>Passageiros</strong><p>${passageirosQtd} viajante(s)</p><button type="button" data-edit-step="4">Editar</button></div>
+        <div class="review-card"><strong>Valores</strong><p>Total: R$ ${valorTotalTxt}</p><p>Lucro: R$ ${lucroTxt}</p><button type="button" data-edit-step="5">Editar</button></div>
+    `;
+    reviewGrid.querySelectorAll('[data-edit-step]').forEach((btn) => btn.addEventListener('click', () => setStep(Number(btn.dataset.editStep))));
+}
+
+if (prevButton) prevButton.addEventListener('click', () => setStep(currentStep - 1));
+if (nextButton) nextButton.addEventListener('click', () => {
+    if (!validateStep(currentStep)) {
+        alert('Preencha os campos obrigatórios desta etapa antes de avançar.');
+        return;
+    }
+    setStep(currentStep + 1);
+});
+stepperItems.forEach((item) => item.addEventListener('click', () => {
+    const target = Number(item.dataset.goStep);
+    if (target <= currentStep) setStep(target);
+}));
+
+document.querySelector('form')?.addEventListener('input', saveDraft);
+document.querySelector('form')?.addEventListener('change', saveDraft);
+document.querySelector('form')?.addEventListener('submit', () => localStorage.removeItem(DRAFT_KEY));
+
+restoreDraft();
+toggleTitularFields();
+updateProgramaOptions();
+recalcValoresFinanceiros();
+renderPassengerForms();
+setVoltaVisibility();
+setStep(currentStep);
 </script>
 {% endblock %}

--- a/src/app/components/EmissionWizard.tsx
+++ b/src/app/components/EmissionWizard.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './emission-wizard.css';
+import { EmissionSidebar } from './wizard-steps/EmissionSidebar';
+import { StepCliente } from './wizard-steps/StepCliente';
+import { StepPassageiros } from './wizard-steps/StepPassageiros';
+import { StepRevisao } from './wizard-steps/StepRevisao';
+import { StepValores } from './wizard-steps/StepValores';
+import { StepVooIda } from './wizard-steps/StepVooIda';
+import { StepVooVolta } from './wizard-steps/StepVooVolta';
+import { EmissionData, StepId } from './wizard-steps/types';
+import { useEmissionValidation } from '../hooks/useEmissionValidation';
+import { validateAll } from '../utils/emissionValidation';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { WizardStepper } from './wizard-steps/WizardStepper';
+
+const STORAGE_KEY = 'emission_wizard_draft';
+
+const initialData: EmissionData = {
+  tipoEmissao: '',
+  clienteId: '',
+  programaId: '',
+  vooIda: { origem: '', destino: '', companhia: '', dataHora: '', possuiEscala: false, escalas: [] },
+  possuiVolta: false,
+  vooVolta: { origem: '', destino: '', companhia: '', dataHora: '', possuiEscala: false, escalas: [] },
+  passageiros: [],
+  valores: {
+    quantidadeMilhas: 0,
+    custoMilhas: 0,
+    taxas: 0,
+    valorMilheiros: 0,
+    valorFinalCliente: 0,
+    valorTotalFinal: 0,
+    lucro: 0,
+    margemPercentual: 0,
+    valorReferencia: 0,
+    economiaObtida: 0,
+    economiaPercentual: 0,
+  },
+  localizador: '',
+  observacoes: '',
+};
+
+const mockCreateEmission = (payload: EmissionData) =>
+  new Promise<{ id: string }>((resolve) => setTimeout(() => resolve({ id: `EM-${Date.now()}` }), 1200));
+
+export const EmissionWizard: React.FC = () => {
+  const [currentStep, setCurrentStep] = useState<StepId>(1);
+  const [emissionData, setEmissionData] = useState<EmissionData>(initialData);
+  const [lastSavedAt, setLastSavedAt] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { errors } = useEmissionValidation(currentStep, emissionData);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as { step: StepId; data: EmissionData };
+      setEmissionData(parsed.data);
+      setCurrentStep(parsed.step);
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ step: currentStep, data: emissionData }));
+    setLastSavedAt(new Date().toLocaleTimeString('pt-BR'));
+  }, [currentStep, emissionData]);
+
+  useEffect(() => {
+    const { quantidadeMilhas, custoMilhas, taxas, valorTotalFinal, valorReferencia } = emissionData.valores;
+    const valorMilheiros = (quantidadeMilhas / 1000) * custoMilhas;
+    const valorFinalCliente = valorMilheiros + taxas;
+    const lucro = valorTotalFinal - valorMilheiros - taxas;
+    const margemPercentual = valorTotalFinal > 0 ? (lucro / valorTotalFinal) * 100 : 0;
+    const economiaObtida = valorReferencia > 0 ? valorReferencia - valorTotalFinal : 0;
+    const economiaPercentual = valorReferencia > 0 ? (economiaObtida / valorReferencia) * 100 : 0;
+
+    setEmissionData((prev) => ({
+      ...prev,
+      valores: {
+        ...prev.valores,
+        valorMilheiros,
+        valorFinalCliente,
+        lucro,
+        margemPercentual,
+        economiaObtida,
+        economiaPercentual,
+      },
+    }));
+  }, [emissionData.valores.quantidadeMilhas, emissionData.valores.custoMilhas, emissionData.valores.taxas, emissionData.valores.valorTotalFinal, emissionData.valores.valorReferencia]);
+
+  const updateEmissionData = (patch: Partial<EmissionData>) => {
+    setEmissionData((prev) => ({ ...prev, ...patch }));
+  };
+
+  const handleNext = () => {
+    if (Object.keys(errors).length) return;
+    setCurrentStep((prev) => Math.min(6, (prev + 1) as StepId));
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handlePrevious = () => {
+    setCurrentStep((prev) => Math.max(1, (prev - 1) as StepId));
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleStepClick = (stepId: StepId) => {
+    if (stepId <= currentStep) {
+      setCurrentStep(stepId);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  const handleFinish = async () => {
+    const allErrors = validateAll(emissionData);
+    if (Object.keys(allErrors).length) {
+      alert('Há campos pendentes. Revise as etapas antes de finalizar.');
+      return;
+    }
+    setIsSaving(true);
+    await mockCreateEmission(emissionData);
+    localStorage.removeItem(STORAGE_KEY);
+    setIsSaving(false);
+    window.location.assign('/admin/emissoes/');
+  };
+
+  const currentStepComponent = useMemo(() => {
+    const props = { data: emissionData, errors, onUpdate: updateEmissionData };
+    if (currentStep === 1) return <StepCliente {...props} />;
+    if (currentStep === 2) return <StepVooIda {...props} />;
+    if (currentStep === 3) return <StepVooVolta {...props} />;
+    if (currentStep === 4) return <StepPassageiros {...props} />;
+    if (currentStep === 5) return <StepValores {...props} />;
+    return <StepRevisao data={emissionData} loading={isSaving} onEdit={(step) => setCurrentStep(step as StepId)} onFinish={handleFinish} />;
+  }, [currentStep, emissionData, errors, isSaving]);
+
+  return (
+    <div className='min-h-screen bg-slate-950 text-white p-6 space-y-6'>
+      <header>
+        <h1 className='text-4xl font-bold'>Nova Emissão</h1>
+        <p className='text-gray-300'>Preencha os dados para criar uma nova emissão de passagem</p>
+      </header>
+
+      <section className='rounded-xl border border-slate-700 bg-slate-800 p-4'>
+        <WizardStepper currentStep={currentStep} onStepClick={handleStepClick} />
+      </section>
+
+      <section className='grid lg:grid-cols-[1fr_340px] gap-5'>
+        <div className='rounded-xl border border-slate-700 bg-slate-800 p-6 space-y-6'>
+          {currentStepComponent}
+          <div className='flex justify-between pt-2'>
+            <button type='button' className='btn-outline' onClick={handlePrevious} disabled={currentStep === 1}><ChevronLeft size={16} /> Voltar</button>
+            {currentStep < 6 && <button type='button' className='btn' onClick={handleNext}>Próximo <ChevronRight size={16} /></button>}
+          </div>
+        </div>
+        <EmissionSidebar data={emissionData} lastSavedAt={lastSavedAt} />
+      </section>
+    </div>
+  );
+};
+
+export default EmissionWizard;

--- a/src/app/components/emission-wizard.css
+++ b/src/app/components/emission-wizard.css
@@ -1,0 +1,41 @@
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 10px;
+  padding: 10px 16px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+
+.btn:disabled { opacity: 0.5; }
+
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 10px;
+  padding: 10px 16px;
+  border: 1px solid #475569;
+  color: #fff;
+  background: transparent;
+}
+
+.input {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #fff;
+  padding: 10px 12px;
+}
+
+.review-card {
+  border-radius: 12px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  padding: 14px;
+}

--- a/src/app/components/wizard-steps/EmissionSidebar.tsx
+++ b/src/app/components/wizard-steps/EmissionSidebar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { EmissionData } from './types';
+
+interface Props {
+  data: EmissionData;
+  lastSavedAt: string;
+}
+
+export const EmissionSidebar: React.FC<Props> = ({ data, lastSavedAt }) => (
+  <aside className='rounded-xl border border-gray-700 bg-gray-800 p-5 space-y-4'>
+    <h3 className='text-xl font-semibold text-white'>Resumo da Emissão</h3>
+    <div className='text-sm text-gray-300 space-y-1'>
+      <p>Cliente: <span className='text-white'>{data.clienteId || '-'}</span></p>
+      <p>Programa: <span className='text-white'>{data.programaId || '-'}</span></p>
+      <p>Rota: <span className='text-white'>{data.vooIda.origem || '-'} → {data.vooIda.destino || '-'}</span></p>
+      <p>Passageiros: <span className='text-white'>{data.passageiros.length}</span></p>
+    </div>
+    <div className='pt-3 border-t border-gray-700'>
+      <p className='text-gray-400 text-sm'>Valor Total</p>
+      <p className='text-3xl font-bold text-white'>R$ {data.valores.valorTotalFinal.toFixed(2)}</p>
+      <p className='text-green-400 text-sm'>Lucro: R$ {data.valores.lucro.toFixed(2)}</p>
+    </div>
+    <p className='text-xs text-green-400'>● {lastSavedAt ? `Autossalvo ${lastSavedAt}` : 'Autossalvo ativo'}</p>
+  </aside>
+);

--- a/src/app/components/wizard-steps/StepCliente.tsx
+++ b/src/app/components/wizard-steps/StepCliente.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Option, StepProps, TipoEmissao } from './types';
+
+const TIPOS: Option[] = [
+  { id: 'conta_cliente', label: 'Conta do Cliente', description: 'Cliente usa suas próprias milhas' },
+  { id: 'conta_administradora', label: 'Conta Administradora', description: 'Empresa emite com conta administrada' },
+  { id: 'emissor_parceiro', label: 'Emissor Parceiro', description: 'Emissão com parceiro externo' },
+];
+
+const PROGRAMAS: Option[] = [
+  { id: 'latam', label: 'LATAM Pass', color: 'bg-red-500' },
+  { id: 'smiles', label: 'Smiles', color: 'bg-orange-500' },
+  { id: 'azul', label: 'TudoAzul', color: 'bg-blue-500' },
+  { id: 'privilege', label: 'Privilege Club', color: 'bg-purple-500' },
+];
+
+const CLIENTES: Option[] = [
+  { id: '1', label: 'João Silva - CPF 123.456.789-00' },
+  { id: '2', label: 'Maria Souza - CPF 987.654.321-00' },
+];
+
+export const StepCliente: React.FC<StepProps> = ({ data, errors, onUpdate }) => {
+  return (
+    <div className='space-y-6'>
+      <h2 className='text-2xl font-semibold text-white'>Dados do Cliente</h2>
+
+      <div>
+        <p className='text-sm text-gray-300 mb-2'>Tipo de Emissão *</p>
+        <div className='grid md:grid-cols-3 gap-3'>
+          {TIPOS.map((tipo) => (
+            <button
+              type='button'
+              key={tipo.id}
+              onClick={() => onUpdate({ tipoEmissao: tipo.id as TipoEmissao })}
+              className={`p-4 rounded-xl border text-left transition ${data.tipoEmissao === tipo.id ? 'border-blue-500 bg-blue-500/20' : 'border-gray-700 bg-gray-900'}`}
+            >
+              <p className='text-white font-medium'>{tipo.label}</p>
+              <p className='text-xs text-gray-400'>{tipo.description}</p>
+            </button>
+          ))}
+        </div>
+        {errors.tipoEmissao && <p className='text-red-400 text-sm mt-1'>{errors.tipoEmissao}</p>}
+      </div>
+
+      <div>
+        <label className='text-sm text-gray-300'>Cliente *</label>
+        <select
+          className='mt-1 w-full rounded-lg bg-gray-900 border border-gray-700 p-3 text-white'
+          value={data.clienteId}
+          onChange={(e) => onUpdate({ clienteId: e.target.value })}
+        >
+          <option value=''>Selecione...</option>
+          {CLIENTES.map((c) => <option key={c.id} value={c.id}>{c.label}</option>)}
+        </select>
+        {errors.clienteId && <p className='text-red-400 text-sm mt-1'>{errors.clienteId}</p>}
+      </div>
+
+      <div>
+        <label className='text-sm text-gray-300'>Programa de Milhas *</label>
+        <div className='grid md:grid-cols-4 gap-3 mt-2'>
+          {PROGRAMAS.map((p) => (
+            <button
+              type='button'
+              key={p.id}
+              onClick={() => onUpdate({ programaId: p.id })}
+              className={`p-4 rounded-xl border ${data.programaId === p.id ? 'border-blue-400 bg-blue-500/20' : 'border-gray-700 bg-gray-900'}`}
+            >
+              <span className={`inline-block w-3 h-3 rounded-full ${p.color}`} />
+              <p className='text-white mt-2'>{p.label}</p>
+            </button>
+          ))}
+        </div>
+        {errors.programaId && <p className='text-red-400 text-sm mt-1'>{errors.programaId}</p>}
+      </div>
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/StepPassageiros.tsx
+++ b/src/app/components/wizard-steps/StepPassageiros.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Copy, Plus, Trash2 } from 'lucide-react';
+import { StepProps, TipoPassageiro } from './types';
+
+const labels: Record<TipoPassageiro, string> = { adulto: 'Adulto', crianca: 'Criança', bebe: 'Bebê' };
+
+export const StepPassageiros: React.FC<StepProps> = ({ data, errors, onUpdate }) => {
+  const addPassenger = (tipo: TipoPassageiro) => {
+    onUpdate({
+      passageiros: [...data.passageiros, {
+        id: crypto.randomUUID(),
+        tipo,
+        nome: '', cpf: '', dataNascimento: '', observacoes: '', rg: '', passaporte: '', validadePassaporte: ''
+      }],
+    });
+  };
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-2xl font-semibold text-white'>Passageiros</h2>
+      <div className='flex gap-2'>
+        <button type='button' className='btn' onClick={() => addPassenger('adulto')}><Plus size={16} />Adicionar Adulto</button>
+        <button type='button' className='btn bg-green-600' onClick={() => addPassenger('crianca')}><Plus size={16} />Adicionar Criança</button>
+        <button type='button' className='btn bg-purple-600' onClick={() => addPassenger('bebe')}><Plus size={16} />Adicionar Bebê</button>
+      </div>
+
+      {errors.passageiros && <p className='text-red-400'>{errors.passageiros}</p>}
+      {data.passageiros.map((p, idx) => (
+        <div key={p.id} className='rounded-xl border border-gray-700 p-4 bg-gray-900/60 space-y-3'>
+          <div className='flex justify-between'>
+            <p className='text-white'><span className='text-blue-400'>{labels[p.tipo]} #{idx + 1}</span> {p.nome}</p>
+            <div className='flex gap-2'>
+              <button type='button' className='btn-outline' onClick={() => onUpdate({ passageiros: [...data.passageiros, { ...p, id: crypto.randomUUID() }] })}><Copy size={14} /></button>
+              <button type='button' className='btn-outline' onClick={() => onUpdate({ passageiros: data.passageiros.filter((item) => item.id !== p.id) })}><Trash2 size={14} /></button>
+            </div>
+          </div>
+
+          <div className='grid md:grid-cols-2 gap-3'>
+            <input className='input' placeholder='Nome completo' value={p.nome} onChange={(e) => {
+              const passageiros = [...data.passageiros]; passageiros[idx] = { ...p, nome: e.target.value }; onUpdate({ passageiros });
+            }} />
+            <input className='input' placeholder='CPF' value={p.cpf} onChange={(e) => {
+              const passageiros = [...data.passageiros]; passageiros[idx] = { ...p, cpf: e.target.value }; onUpdate({ passageiros });
+            }} />
+            <input className='input' type='date' placeholder='Nascimento' value={p.dataNascimento} onChange={(e) => {
+              const passageiros = [...data.passageiros]; passageiros[idx] = { ...p, dataNascimento: e.target.value }; onUpdate({ passageiros });
+            }} />
+            <input className='input' placeholder='Passaporte (opcional)' value={p.passaporte} onChange={(e) => {
+              const passageiros = [...data.passageiros]; passageiros[idx] = { ...p, passaporte: e.target.value }; onUpdate({ passageiros });
+            }} />
+          </div>
+          {(errors[`passageiroNome-${idx}`] || errors[`passageiroCpf-${idx}`] || errors[`passageiroNascimento-${idx}`] || errors[`passageiroTipo-${idx}`]) && (
+            <p className='text-red-400 text-sm'>{errors[`passageiroNome-${idx}`] || errors[`passageiroCpf-${idx}`] || errors[`passageiroNascimento-${idx}`] || errors[`passageiroTipo-${idx}`]}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/StepRevisao.tsx
+++ b/src/app/components/wizard-steps/StepRevisao.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import { EmissionData } from './types';
+
+interface Props {
+  data: EmissionData;
+  loading: boolean;
+  onEdit: (step: number) => void;
+  onFinish: () => void;
+}
+
+export const StepRevisao: React.FC<Props> = ({ data, loading, onEdit, onFinish }) => {
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-2xl font-semibold text-white'>Revisão Final</h2>
+      <div className='review-card'>
+        <p className='text-white font-medium'>Cliente & Programa</p>
+        <p className='text-gray-300'>{data.clienteId} • {data.programaId}</p>
+        <button className='btn-outline' type='button' onClick={() => onEdit(1)}>Editar</button>
+      </div>
+      <div className='review-card'>
+        <p className='text-white font-medium'>Rota</p>
+        <p className='text-gray-300'>{data.vooIda.origem} → {data.vooIda.destino}</p>
+        <button className='btn-outline' type='button' onClick={() => onEdit(2)}>Editar</button>
+      </div>
+      <div className='review-card'>
+        <p className='text-white font-medium'>Passageiros</p>
+        <p className='text-gray-300'>{data.passageiros.length} pessoa(s)</p>
+        <button className='btn-outline' type='button' onClick={() => onEdit(4)}>Editar</button>
+      </div>
+      <div className='rounded-xl border border-green-500/40 bg-green-900/20 p-4 text-green-300'>Pronto para finalizar!</div>
+      <button type='button' onClick={onFinish} className='btn bg-green-600 w-full' disabled={loading}>
+        {loading ? <><Loader2 className='animate-spin' size={16} /> Salvando...</> : 'Finalizar Emissão'}
+      </button>
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/StepValores.tsx
+++ b/src/app/components/wizard-steps/StepValores.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StepProps } from './types';
+
+export const StepValores: React.FC<StepProps> = ({ data, errors, onUpdate }) => {
+  const valores = data.valores;
+  const update = (patch: Partial<typeof valores>) => onUpdate({ valores: { ...valores, ...patch } });
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-2xl font-semibold text-white'>Valores e Financeiro</h2>
+      <div className='grid md:grid-cols-2 gap-3'>
+        <input className='input' type='number' placeholder='Quantidade de milhas' value={valores.quantidadeMilhas || ''} onChange={(e) => update({ quantidadeMilhas: Number(e.target.value) })} />
+        <input className='input' type='number' step='0.01' placeholder='Custo por milheiro' value={valores.custoMilhas || ''} onChange={(e) => update({ custoMilhas: Number(e.target.value) })} />
+        <input className='input' type='number' step='0.01' placeholder='Taxas' value={valores.taxas || ''} onChange={(e) => update({ taxas: Number(e.target.value) })} />
+        <input className='input opacity-70' disabled value={valores.valorMilheiros.toFixed(2)} />
+      </div>
+      {(errors.quantidadeMilhas || errors.custoMilhas || errors.taxas) && <p className='text-red-400 text-sm'>{errors.quantidadeMilhas || errors.custoMilhas || errors.taxas}</p>}
+
+      <div className='grid md:grid-cols-2 gap-3'>
+        <input className='input opacity-70' disabled value={valores.valorFinalCliente.toFixed(2)} />
+        <input className='input' type='number' step='0.01' placeholder='Valor Total Final' value={valores.valorTotalFinal || ''} onChange={(e) => update({ valorTotalFinal: Number(e.target.value) })} />
+        <input className='input' type='number' step='0.01' placeholder='Valor de Referência' value={valores.valorReferencia || ''} onChange={(e) => update({ valorReferencia: Number(e.target.value) })} />
+      </div>
+      {errors.valorTotalFinal && <p className='text-red-400 text-sm'>{errors.valorTotalFinal}</p>}
+
+      <div className='grid md:grid-cols-2 gap-3'>
+        <div className={`rounded-xl p-4 border ${valores.lucro >= 0 ? 'border-green-500/30 bg-green-900/20' : 'border-red-500/30 bg-red-900/20'}`}>
+          <p className='text-sm text-gray-300'>Lucro Estimado</p>
+          <p className='text-3xl font-semibold text-white'>R$ {valores.lucro.toFixed(2)}</p>
+          <p className='text-sm text-gray-300'>{valores.margemPercentual.toFixed(1)}% de margem</p>
+        </div>
+        <div className='rounded-xl p-4 border border-blue-500/30 bg-blue-900/20'>
+          <p className='text-sm text-gray-300'>Economia do Cliente</p>
+          <p className='text-3xl font-semibold text-blue-300'>R$ {valores.economiaObtida.toFixed(2)}</p>
+          <p className='text-sm text-gray-300'>{valores.economiaPercentual.toFixed(1)}% de desconto</p>
+        </div>
+      </div>
+
+      <div className='grid md:grid-cols-2 gap-3'>
+        <input className='input uppercase' maxLength={6} placeholder='Localizador' value={data.localizador} onChange={(e) => onUpdate({ localizador: e.target.value.toUpperCase() })} />
+        <textarea className='input h-24' placeholder='Observações' value={data.observacoes} onChange={(e) => onUpdate({ observacoes: e.target.value })} />
+      </div>
+      {errors.localizador && <p className='text-red-400 text-sm'>{errors.localizador}</p>}
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/StepVooIda.tsx
+++ b/src/app/components/wizard-steps/StepVooIda.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { StepProps } from './types';
+import { normalizeIata } from '../../utils/emissionValidation';
+
+export const StepVooIda: React.FC<StepProps> = ({ data, errors, onUpdate }) => {
+  const voo = data.vooIda;
+
+  const updateVoo = (patch: Partial<typeof voo>) => onUpdate({ vooIda: { ...voo, ...patch } });
+
+  return (
+    <div className='space-y-5'>
+      <h2 className='text-2xl font-semibold text-white'>Voo de Ida</h2>
+      <div className='grid md:grid-cols-2 gap-4'>
+        <input className='input' placeholder='IATA Origem' value={voo.origem} onChange={(e) => updateVoo({ origem: normalizeIata(e.target.value) })} />
+        <input className='input' placeholder='IATA Destino' value={voo.destino} onChange={(e) => updateVoo({ destino: normalizeIata(e.target.value) })} />
+      </div>
+      {(errors.vooIdaOrigem || errors.vooIdaDestino || errors.vooIdaRota) && <p className='text-red-400 text-sm'>{errors.vooIdaOrigem || errors.vooIdaDestino || errors.vooIdaRota}</p>}
+
+      {voo.origem && voo.destino && (
+        <div className='rounded-xl border border-blue-500/40 bg-gradient-to-r from-blue-900/60 to-purple-900/60 p-4 text-white font-semibold'>
+          {voo.origem} → {voo.destino}
+        </div>
+      )}
+
+      <div className='grid md:grid-cols-2 gap-4'>
+        <input className='input' placeholder='Companhia aérea' value={voo.companhia} onChange={(e) => updateVoo({ companhia: e.target.value })} />
+        <input className='input' type='datetime-local' value={voo.dataHora} onChange={(e) => updateVoo({ dataHora: e.target.value })} />
+      </div>
+      {(errors.vooIdaCompanhia || errors.vooIdaDataHora) && <p className='text-red-400 text-sm'>{errors.vooIdaCompanhia || errors.vooIdaDataHora}</p>}
+
+      <label className='inline-flex items-center gap-2 text-gray-200'>
+        <input type='checkbox' checked={voo.possuiEscala} onChange={(e) => updateVoo({ possuiEscala: e.target.checked, escalas: e.target.checked ? voo.escalas : [] })} />
+        Este voo possui escalas?
+      </label>
+
+      {voo.possuiEscala && (
+        <div className='space-y-3'>
+          {voo.escalas.map((escala, idx) => (
+            <div key={escala.id} className='grid md:grid-cols-4 gap-2 items-center'>
+              <input className='input' placeholder='IATA' value={escala.iata} onChange={(e) => {
+                const escalas = [...voo.escalas];
+                escalas[idx] = { ...escala, iata: normalizeIata(e.target.value) };
+                updateVoo({ escalas });
+              }} />
+              <input className='input' placeholder='Companhia' value={escala.companhia} onChange={(e) => {
+                const escalas = [...voo.escalas];
+                escalas[idx] = { ...escala, companhia: e.target.value };
+                updateVoo({ escalas });
+              }} />
+              <input className='input' type='time' value={escala.horario} onChange={(e) => {
+                const escalas = [...voo.escalas];
+                escalas[idx] = { ...escala, horario: e.target.value };
+                updateVoo({ escalas });
+              }} />
+              <button type='button' className='btn-outline' onClick={() => updateVoo({ escalas: voo.escalas.filter((_, i) => i !== idx) })}><Trash2 size={16} /></button>
+            </div>
+          ))}
+          <button type='button' className='btn-outline' onClick={() => updateVoo({ escalas: [...voo.escalas, { id: crypto.randomUUID(), iata: '', companhia: '', horario: '' }] })}><Plus size={16} /> Adicionar Escala</button>
+          {Object.keys(errors).some((k) => k.startsWith('vooIdaEscala')) && <p className='text-red-400 text-sm'>Complete os dados das escalas.</p>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/StepVooVolta.tsx
+++ b/src/app/components/wizard-steps/StepVooVolta.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { StepProps } from './types';
+import { normalizeIata } from '../../utils/emissionValidation';
+
+export const StepVooVolta: React.FC<StepProps> = ({ data, errors, onUpdate }) => {
+  const voo = data.vooVolta;
+  const updateVoo = (patch: Partial<typeof voo>) => onUpdate({ vooVolta: { ...voo, ...patch } });
+
+  const invertRoute = () => {
+    onUpdate({
+      vooVolta: {
+        ...voo,
+        origem: data.vooIda.destino,
+        destino: data.vooIda.origem,
+        companhia: data.vooIda.companhia,
+      },
+    });
+  };
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-2xl font-semibold text-white'>Voo de Volta</h2>
+      <label className='inline-flex items-center gap-2 text-gray-200'>
+        <input type='checkbox' checked={data.possuiVolta} onChange={(e) => onUpdate({ possuiVolta: e.target.checked })} />
+        Esta emissão possui voo de volta?
+      </label>
+
+      {!data.possuiVolta ? (
+        <div className='rounded-lg border border-blue-500/30 bg-blue-900/20 p-4 text-blue-300'>One-way habilitado</div>
+      ) : (
+        <>
+          <button type='button' className='btn-outline' onClick={invertRoute}>Inverter Rota</button>
+          <div className='grid md:grid-cols-2 gap-4'>
+            <input className='input' placeholder='IATA Origem' value={voo.origem} onChange={(e) => updateVoo({ origem: normalizeIata(e.target.value) })} />
+            <input className='input' placeholder='IATA Destino' value={voo.destino} onChange={(e) => updateVoo({ destino: normalizeIata(e.target.value) })} />
+            <input className='input' placeholder='Companhia aérea' value={voo.companhia} onChange={(e) => updateVoo({ companhia: e.target.value })} />
+            <input className='input' type='datetime-local' value={voo.dataHora} onChange={(e) => updateVoo({ dataHora: e.target.value })} />
+          </div>
+          {(errors.vooVoltaOrigem || errors.vooVoltaDestino || errors.vooVoltaCompanhia || errors.vooVoltaDataHora) && <p className='text-red-400 text-sm'>{errors.vooVoltaOrigem || errors.vooVoltaDestino || errors.vooVoltaCompanhia || errors.vooVoltaDataHora}</p>}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/app/components/wizard-steps/WizardStepper.tsx
+++ b/src/app/components/wizard-steps/WizardStepper.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+import { StepId } from './types';
+
+const STEPS = [
+  { id: 1, title: 'Cliente & Programa' },
+  { id: 2, title: 'Voo de Ida' },
+  { id: 3, title: 'Voo de Volta' },
+  { id: 4, title: 'Passageiros' },
+  { id: 5, title: 'Valores' },
+  { id: 6, title: 'Revisão' },
+] as const;
+
+interface Props {
+  currentStep: StepId;
+  onStepClick: (id: StepId) => void;
+}
+
+export const WizardStepper: React.FC<Props> = ({ currentStep, onStepClick }) => (
+  <div className='grid grid-cols-6 gap-2'>
+    {STEPS.map((step, idx) => {
+      const isComplete = step.id < currentStep;
+      const isCurrent = step.id === currentStep;
+      const blocked = step.id > currentStep;
+      return (
+        <button key={step.id} type='button' disabled={blocked} onClick={() => onStepClick(step.id as StepId)} className='flex flex-col items-center gap-2'>
+          <div className={`w-10 h-10 rounded-full flex items-center justify-center transition ${isComplete ? 'bg-green-500' : isCurrent ? 'bg-blue-600 ring-4 ring-blue-500/30' : 'bg-gray-700 text-gray-400'}`}>
+            {isComplete ? <Check size={16} /> : step.id}
+          </div>
+          <span className={`${isCurrent || isComplete ? 'text-white' : 'text-gray-500'} text-xs`}>{step.title}</span>
+          {idx < 5 && <span className={`hidden md:block h-[2px] w-full ${step.id < currentStep ? 'bg-green-500' : 'bg-gray-700'}`} />}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/src/app/components/wizard-steps/types.ts
+++ b/src/app/components/wizard-steps/types.ts
@@ -1,0 +1,76 @@
+export type StepId = 1 | 2 | 3 | 4 | 5 | 6;
+
+export type TipoEmissao = 'conta_cliente' | 'conta_administradora' | 'emissor_parceiro' | '';
+export type TipoPassageiro = 'adulto' | 'crianca' | 'bebe';
+
+export interface EscalaData {
+  id: string;
+  iata: string;
+  companhia: string;
+  horario: string;
+}
+
+export interface VooData {
+  origem: string;
+  destino: string;
+  companhia: string;
+  dataHora: string;
+  possuiEscala: boolean;
+  escalas: EscalaData[];
+}
+
+export interface PassageiroData {
+  id: string;
+  tipo: TipoPassageiro;
+  nome: string;
+  cpf: string;
+  rg?: string;
+  passaporte?: string;
+  validadePassaporte?: string;
+  dataNascimento: string;
+  observacoes?: string;
+}
+
+export interface ValoresData {
+  quantidadeMilhas: number;
+  custoMilhas: number;
+  taxas: number;
+  valorMilheiros: number;
+  valorFinalCliente: number;
+  valorTotalFinal: number;
+  lucro: number;
+  margemPercentual: number;
+  valorReferencia: number;
+  economiaObtida: number;
+  economiaPercentual: number;
+}
+
+export interface EmissionData {
+  tipoEmissao: TipoEmissao;
+  clienteId: string;
+  programaId: string;
+  vooIda: VooData;
+  possuiVolta: boolean;
+  vooVolta: VooData;
+  passageiros: PassageiroData[];
+  valores: ValoresData;
+  localizador: string;
+  observacoes: string;
+}
+
+export interface ValidationErrors {
+  [key: string]: string;
+}
+
+export interface Option {
+  id: string;
+  label: string;
+  description?: string;
+  color?: string;
+}
+
+export interface StepProps {
+  data: EmissionData;
+  errors: ValidationErrors;
+  onUpdate: (patch: Partial<EmissionData>) => void;
+}

--- a/src/app/hooks/useEmissionValidation.ts
+++ b/src/app/hooks/useEmissionValidation.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import { EmissionData, StepId } from '../components/wizard-steps/types';
+import { validateStep } from '../utils/emissionValidation';
+
+export const useEmissionValidation = (step: StepId, data: EmissionData) => {
+  const errors = useMemo(() => validateStep(data, step), [data, step]);
+  const isValid = Object.keys(errors).length === 0;
+  return { errors, isValid };
+};

--- a/src/app/utils/emissionValidation.ts
+++ b/src/app/utils/emissionValidation.ts
@@ -1,0 +1,104 @@
+import { EmissionData, PassageiroData, StepId, ValidationErrors } from '../components/wizard-steps/types';
+
+const IATA_REGEX = /^[A-Z]{3}$/;
+
+export const normalizeIata = (value: string) => value.toUpperCase().replace(/[^A-Z]/g, '').slice(0, 3);
+
+export function isFutureDate(value: string): boolean {
+  if (!value) return false;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) && date.getTime() > Date.now();
+}
+
+export function isValidCPF(cpf: string): boolean {
+  const clean = cpf.replace(/\D/g, '');
+  if (clean.length !== 11 || /^(\d)\1+$/.test(clean)) return false;
+
+  const calcDigit = (base: string, factor: number) => {
+    let total = 0;
+    for (const num of base) {
+      total += Number(num) * factor;
+      factor -= 1;
+    }
+    const remainder = (total * 10) % 11;
+    return remainder === 10 ? 0 : remainder;
+  };
+
+  const digit1 = calcDigit(clean.slice(0, 9), 10);
+  const digit2 = calcDigit(clean.slice(0, 10), 11);
+  return digit1 === Number(clean[9]) && digit2 === Number(clean[10]);
+}
+
+export function getAge(dateISO: string): number {
+  if (!dateISO) return 0;
+  const birth = new Date(dateISO);
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const month = today.getMonth() - birth.getMonth();
+  if (month < 0 || (month === 0 && today.getDate() < birth.getDate())) age -= 1;
+  return age;
+}
+
+function validatePassengerByType(p: PassageiroData): string | null {
+  const age = getAge(p.dataNascimento);
+  if (p.tipo === 'adulto' && age < 12) return 'Adulto deve ter ao menos 12 anos';
+  if (p.tipo === 'crianca' && (age < 2 || age >= 12)) return 'Criança deve ter entre 2 e 11 anos';
+  if (p.tipo === 'bebe' && age >= 2) return 'Bebê deve ter menos de 2 anos';
+  return null;
+}
+
+export function validateStep(data: EmissionData, step: StepId): ValidationErrors {
+  const errors: ValidationErrors = {};
+
+  if (step === 1) {
+    if (!data.tipoEmissao) errors.tipoEmissao = 'Selecione o tipo de emissão';
+    if (!data.clienteId) errors.clienteId = 'Selecione o cliente';
+    if (!data.programaId) errors.programaId = 'Selecione o programa';
+  }
+
+  if (step === 2) {
+    if (!IATA_REGEX.test(data.vooIda.origem)) errors.vooIdaOrigem = 'Origem deve ter 3 letras';
+    if (!IATA_REGEX.test(data.vooIda.destino)) errors.vooIdaDestino = 'Destino deve ter 3 letras';
+    if (data.vooIda.origem && data.vooIda.origem === data.vooIda.destino) errors.vooIdaRota = 'Origem e destino devem ser diferentes';
+    if (!data.vooIda.companhia) errors.vooIdaCompanhia = 'Companhia é obrigatória';
+    if (!isFutureDate(data.vooIda.dataHora)) errors.vooIdaDataHora = 'Data da ida deve ser futura';
+    data.vooIda.escalas.forEach((escala, idx) => {
+      if (!IATA_REGEX.test(escala.iata) || !escala.companhia || !escala.horario) {
+        errors[`vooIdaEscala-${idx}`] = 'Complete os dados da escala';
+      }
+    });
+  }
+
+  if (step === 3 && data.possuiVolta) {
+    if (!IATA_REGEX.test(data.vooVolta.origem)) errors.vooVoltaOrigem = 'Origem deve ter 3 letras';
+    if (!IATA_REGEX.test(data.vooVolta.destino)) errors.vooVoltaDestino = 'Destino deve ter 3 letras';
+    if (data.vooVolta.origem && data.vooVolta.origem === data.vooVolta.destino) errors.vooVoltaRota = 'Origem e destino devem ser diferentes';
+    if (!data.vooVolta.companhia) errors.vooVoltaCompanhia = 'Companhia é obrigatória';
+    if (!isFutureDate(data.vooVolta.dataHora)) errors.vooVoltaDataHora = 'Data da volta deve ser futura';
+  }
+
+  if (step === 4) {
+    if (!data.passageiros.length) errors.passageiros = 'Adicione ao menos um passageiro';
+    data.passageiros.forEach((p, idx) => {
+      if (!p.nome) errors[`passageiroNome-${idx}`] = 'Nome obrigatório';
+      if (!isValidCPF(p.cpf)) errors[`passageiroCpf-${idx}`] = 'CPF inválido';
+      if (!p.dataNascimento) errors[`passageiroNascimento-${idx}`] = 'Data de nascimento obrigatória';
+      const ageError = validatePassengerByType(p);
+      if (ageError) errors[`passageiroTipo-${idx}`] = ageError;
+    });
+  }
+
+  if (step === 5) {
+    if (data.valores.quantidadeMilhas <= 0) errors.quantidadeMilhas = 'Milhas deve ser maior que zero';
+    if (data.valores.custoMilhas <= 0) errors.custoMilhas = 'Custo do milheiro deve ser maior que zero';
+    if (data.valores.taxas < 0) errors.taxas = 'Taxas não pode ser negativo';
+    if (data.valores.valorTotalFinal <= 0) errors.valorTotalFinal = 'Valor total final deve ser maior que zero';
+    if (data.localizador && data.localizador.length !== 6) errors.localizador = 'Localizador deve ter 6 caracteres';
+  }
+
+  return errors;
+}
+
+export function validateAll(data: EmissionData): ValidationErrors {
+  return [1, 2, 3, 4, 5].reduce<ValidationErrors>((acc, step) => ({ ...acc, ...validateStep(data, step as StepId) }), {});
+}


### PR DESCRIPTION
### Motivation
- Provide a step-by-step wizard UI for creating and editing emission records to improve user flow and reduce data loss via local autosave.
- Introduce reusable React wizard components to support a gradual migration from the current Django form to a client-side interface while keeping the existing server form submission intact.
- Add client-side validation and a review step to prevent common input mistakes before saving the emission.

### Description
- Added wizard styling and responsive stepper rules to `gestao/static/gestao/formulario_base_gestao.css` and introduced `review-grid`/`review-card` styles for the review step.
- Updated the Django template `gestao/templates/admin_custom/form_emissao_passagem.html` to render a visual stepper header, mark per-step containers with `wizard-step` and `data-step`, insert a review card (`#review-grid`), and add navigation buttons (`#wizard-prev`, `#wizard-next`), plus integrated inline JS that implements per-step validation, autosave/restore to `localStorage` (`emission_draft_v2`), and summary generation.
- Added a new React-based wizard under `src/app/components` with `EmissionWizard.tsx`, the step components in `wizard-steps/*` (`StepCliente`, `StepVooIda`, `StepVooVolta`, `StepPassageiros`, `StepValores`, `StepRevisao`, `WizardStepper`, `EmissionSidebar`, and `types.ts`), plus styles in `emission-wizard.css` and a `useEmissionValidation` hook.
- Implemented validation and helper utilities in `src/app/utils/emissionValidation.ts` providing IATA normalization, CPF validation, age calculation, `validateStep`, and `validateAll`, and wired client-side persistence for the React wizard using `localStorage` key `emission_wizard_draft` with a mock submit flow.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4885ef5e083278289c50d1a1c66ab)